### PR TITLE
codegen: remove makeError and translate the errors in the generated code

### DIFF
--- a/internal/codegen/templates/file.tmpl
+++ b/internal/codegen/templates/file.tmpl
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"unsafe"
 	"github.com/go-ole/go-ole"
-	"github.com/saltosystems/winrt-go/winrt"
 	{{range .Imports}}"{{.}}"
 	{{end}}
 )
@@ -15,10 +14,3 @@ import (
 {{range .Types}}
 {{template "type.tmpl" .}}
 {{end}}
-
-func makeError(hr uintptr) error {
-	if hr != 0 {
-		return ole.NewError(hr)
-	}
-	return nil
-}

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -23,8 +23,8 @@
         {{end}})
 
     
-    if err := winrt.MakeError(hr); err != nil {
-        return {{if .ReturnParam }}{{.ReturnParam.DefaultValue}}, {{end}}err
+    if hr != 0 {
+        return {{if .ReturnParam }}{{.ReturnParam.DefaultValue}}, {{end}}ole.NewError(hr)
     }
 
     return {{if .ReturnParam }}out, {{end}}nil

--- a/winrt/windows/storage/streams/buffer/buffer.go
+++ b/winrt/windows/storage/streams/buffer/buffer.go
@@ -5,7 +5,6 @@ package buffer
 
 import (
 	"github.com/go-ole/go-ole"
-	"github.com/saltosystems/winrt-go/winrt"
 	"syscall"
 	"unsafe"
 )
@@ -38,8 +37,8 @@ func (v *IBuffer) GetCapacity() (uint32, error) {
 		uintptr(unsafe.Pointer(&out)), // out uint32
 	)
 
-	if err := winrt.MakeError(hr); err != nil {
-		return 0, err
+	if hr != 0 {
+		return 0, ole.NewError(hr)
 	}
 
 	return out, nil
@@ -57,8 +56,8 @@ func (v *IBuffer) GetLength() (uint32, error) {
 		uintptr(unsafe.Pointer(&out)), // out uint32
 	)
 
-	if err := winrt.MakeError(hr); err != nil {
-		return 0, err
+	if hr != 0 {
+		return 0, ole.NewError(hr)
 	}
 
 	return out, nil
@@ -74,8 +73,8 @@ func (v *IBuffer) SetLength(value uint32) error {
 		uintptr(value), // in value
 	)
 
-	if err := winrt.MakeError(hr); err != nil {
-		return err
+	if hr != 0 {
+		return ole.NewError(hr)
 	}
 
 	return nil
@@ -117,16 +116,9 @@ func (v *IBufferFactory) Create(capacity uint32) (*IBuffer, error) {
 		uintptr(unsafe.Pointer(&out)), // out *IBuffer
 	)
 
-	if err := winrt.MakeError(hr); err != nil {
-		return nil, err
+	if hr != 0 {
+		return nil, ole.NewError(hr)
 	}
 
 	return out, nil
-}
-
-func makeError(hr uintptr) error {
-	if hr != 0 {
-		return ole.NewError(hr)
-	}
-	return nil
 }


### PR DESCRIPTION
This was broken in the previous PR. The GitHub workflow passed so I assumed everything was fine. Apparently it wasn't, because the generated code is not part of the building process.