### PR TITLE
winrt: add windows workflow to run tests and check the generated code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,8 @@ on:
       - main
 
 jobs:
-  build:
+  # project should compile on non-windows platforms
+  build-ubuntu:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -32,3 +33,31 @@ jobs:
         run: |
           docker exec -i winrt-go make clean
           docker stop winrt-go
+
+  # but tests only run on windows
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.2
+      - name: init
+        run: |
+          curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/v1.46.2/install.sh | sh -s -- -b "$(go env GOPATH)/bin" v1.46.2
+      - name: prepare
+        run: make prepare
+      - name: sanity-check
+        run: make sanity-check
+      - name: build
+        run: make build
+      - name: test
+        run: make test
+      - name: release
+        if: github.ref == 'refs/heads/main'
+        run: make release
+      - name: clean
+        run: |
+          make clean
+

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ sanity-check: $(sanity_check_targets)
 build: $(build_targets)
 
 .PHONY: test
-test: $(test_targets)
+test: $(test_targets) go-test
 
 .PHONY: release
 release: $(release_targets)
@@ -26,3 +26,7 @@ clean: $(clean_targets)
 .PHONY: gen-files
 gen-files:
 	go generate github.com/saltosystems/winrt-go/...
+
+.PHONY: go-test
+go-test:
+	go test github.com/saltosystems/winrt-go/winrt

--- a/winrt/buffer_test.go
+++ b/winrt/buffer_test.go
@@ -3,6 +3,7 @@
 package winrt_test
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -11,13 +12,21 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	ole.RoInitialize(1)
+	err := ole.RoInitialize(1)
+	if err != nil {
+		log.Fatal(err)
+	}
 	code := m.Run()
 	os.Exit(code)
 }
 
 func TestNewBuffer(t *testing.T) {
-	b, err := buffer.Create(0)
+	bufFactory, err := buffer.ActivateIBufferFactory()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := bufFactory.Create(10)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -28,12 +37,27 @@ func TestNewBuffer(t *testing.T) {
 }
 
 func TestSetCapacity(t *testing.T) {
-	b, err := buffer.Create(0)
+	bufFactory, err := buffer.ActivateIBufferFactory()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	bufferCapacity := uint32(12)
+	b, err := bufFactory.Create(bufferCapacity)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	if b == nil {
 		t.Fatal("b is nil")
+	}
+
+	c, err := b.GetCapacity()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c != bufferCapacity {
+		t.Fatalf("Buffer Capacity was set to 10 but GetCapacity returned %d.", c)
 	}
 }


### PR DESCRIPTION
I'm not really sure if there's any point on keeping the ubuntu workflow. But I thought it was useful to check that `winrt-go-gen` still compiles on non-windows platforms.