### PR TITLE
Makefile: delete old generated code when running the generate command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ clean: $(clean_targets)
 
 .PHONY: gen-files
 gen-files:
+	rm -rf $(CURDIR)/windows
 	go generate github.com/saltosystems/winrt-go/...
 
 .PHONY: go-test


### PR DESCRIPTION
Delete all generated files before calling `go generate`