### PR TITLE
codegen: add GUID to interfaces and return an error if it is private

### DIFF
--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -16,6 +16,7 @@ type genData struct {
 
 type genType struct {
 	Name  string
+	GUID  string
 	Funcs []genFunc
 }
 

--- a/internal/codegen/templates/type.tmpl
+++ b/internal/codegen/templates/type.tmpl
@@ -1,3 +1,7 @@
+{{if .GUID}}
+const GUID{{.Name}} string = "{{.GUID}}"
+{{end}}
+
 type {{.Name}} struct {
     ole.IInspectable
 }

--- a/windows/storage/streams/ibuffer.go
+++ b/windows/storage/streams/ibuffer.go
@@ -11,6 +11,8 @@ import (
 	"unsafe"
 )
 
+const GUIDIBuffer string = "905a0fe0-bc53-11df-8c49-001e4fc686da"
+
 type IBuffer struct {
 	ole.IInspectable
 }


### PR DESCRIPTION
According to the docs all interfaces will have an associated GUID in the
CustomAttributes table. And also all private interfaces are exclusive to
runtime classes, and thus they should only be generated when the runtime
class is generated.