### PR TITLE
codegen: add option to filter methods

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -10,12 +10,26 @@ import (
 	"github.com/saltosystems/winrt-go/internal/codegen"
 )
 
+const methodFilterUsage = `The filter to use when generating the methods. This option can be set several times, 
+the given filters will be applied in order, and the first that matches will determine the result. The generator
+will allow any method by default.
+
+You can use the '!' character to negate a filter. For example, to generate all methods except the 'Add' method:
+    -method-filter !Add
+
+You can also use the '*' character to match any method, so if you want to generate only the 'Add' method, you can do:
+    -method-filter Add -method-filter !*`
+
 // NewGenerateCommand returns a new subcommand for generating code.
 func NewGenerateCommand(logger log.Logger) *subcommands.Command {
 	cfg := codegen.NewConfig()
 	fs := flag.NewFlagSet("winrt-go-gen", flag.ExitOnError)
 	_ = fs.String("config", "", "config file (optional)")
-	fs.StringVar(&cfg.Class, "class", cfg.Class, "The class to generate. This should include the namespace and the class name, e.g. 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken'")
+	fs.StringVar(&cfg.Class, "class", cfg.Class, "The class to generate. This should include the namespace and the class name, e.g. 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken'.")
+	fs.Func("method-filter", methodFilterUsage, func(m string) error {
+		cfg.AddMethodFilter(m)
+		return nil
+	})
 	fs.BoolVar(&cfg.Debug, "debug", cfg.Debug, "Enables the debug logging.")
 	return subcommands.NewCommand(fs.Name(), fs, func() error {
 		if cfg.Debug {

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -28,7 +28,8 @@ func (e *classNotFoundError) Error() string {
 }
 
 type generator struct {
-	class string
+	class        string
+	methodFilter *MethodFilter
 
 	logger log.Logger
 
@@ -43,8 +44,9 @@ func Generate(cfg *Config, logger log.Logger) error {
 	}
 
 	g := &generator{
-		class:  cfg.Class,
-		logger: logger,
+		class:        cfg.Class,
+		methodFilter: cfg.MethodFilter(),
+		logger:       logger,
 	}
 	return g.run()
 }
@@ -372,6 +374,7 @@ func (g *generator) genFuncFromMethod(typeDef, runtimeClass types.TypeDef, m typ
 
 	return &genFunc{
 		Name:           m.Name,
+		Implement:      g.shouldImplementMethod(m),
 		IsConstructor:  false,
 		InParams:       params,
 		ReturnParam:    retParam,
@@ -381,6 +384,10 @@ func (g *generator) genFuncFromMethod(typeDef, runtimeClass types.TypeDef, m typ
 		RuntimeClass:   runtimeClass,
 		FuncOwner:      typeDef.TypeName,
 	}, nil
+}
+
+func (g *generator) shouldImplementMethod(m types.MethodDef) bool {
+	return g.methodFilter.Filter(m.Name)
 }
 
 func (g *generator) typeGUID(typeDef types.TypeDef) (string, error) {

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -4,13 +4,24 @@ import "fmt"
 
 // Config is the configuration for the code generation.
 type Config struct {
-	Debug bool
-	Class string
+	Debug         bool
+	Class         string
+	methodFilters []string
 }
 
 // NewConfig returns a new Config with default values.
 func NewConfig() *Config {
 	return &Config{}
+}
+
+// AddMethodFilter adds a method to the list of methodFilters to generate.
+func (cfg *Config) AddMethodFilter(methodFilter string) {
+	cfg.methodFilters = append(cfg.methodFilters, methodFilter)
+}
+
+// MethodFilter creates and returns a new method filter for the current config.
+func (cfg *Config) MethodFilter() *MethodFilter {
+	return NewMethodFilter(cfg.methodFilters)
 }
 
 // Validate validates the Config and returns an error if there's any problem.
@@ -20,7 +31,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	if cfg.Class == "" {
-		return fmt.Errorf("generated class may not be empty")
+		return fmt.Errorf("generated classes may not be empty")
 	}
 
 	return nil

--- a/internal/codegen/methodfilter.go
+++ b/internal/codegen/methodfilter.go
@@ -1,0 +1,28 @@
+package codegen
+
+// MethodFilter is a filter for methods to be generated.
+type MethodFilter struct {
+	filters []string
+}
+
+// NewMethodFilter creates a new MethodFilter.
+func NewMethodFilter(filters []string) *MethodFilter {
+	return &MethodFilter{filters}
+}
+
+// Filter returns true if the method matches one of the filters.
+// In case no filter matches the method, the method is allowed.
+func (md *MethodFilter) Filter(method string) bool {
+	for _, filter := range md.filters {
+		result := true
+		if filter[0] == '!' {
+			filter = filter[1:]
+			result = false
+		}
+
+		if filter == "*" || filter == method {
+			return result
+		}
+	}
+	return true // everything matches by default
+}

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -24,6 +24,8 @@ type genFunc struct {
 	Name          string
 	IsConstructor bool
 
+	Implement bool
+
 	FuncOwner      string
 	ParentType     types.TypeDef
 	ParentTypeGUID string

--- a/internal/codegen/templates/func.tmpl
+++ b/internal/codegen/templates/func.tmpl
@@ -1,28 +1,30 @@
-func {{if .FuncOwner}}
-    (v *{{.FuncOwner}})
-{{- end -}}
+{{if .Implement}}
+    func {{if .FuncOwner}}
+        (v *{{.FuncOwner}})
+    {{- end -}}
 
-{{funcName .}}
+    {{funcName .}}
 
-{{- /* input params */ -}}
+    {{- /* input params */ -}}
 
-(
-{{- range .InParams -}}
-    {{.Name}} {{.Type}},
-{{- end -}}
-)
+    (
+    {{- range .InParams -}}
+        {{.Name}} {{.Type}},
+    {{- end -}}
+    )
 
-{{- /* return params */ -}}
+    {{- /* return params */ -}}
 
-(
-{{- if .ReturnParam -}}
-    {{.ReturnParam.Type}},
-{{- end -}}
-error)
+    (
+    {{- if .ReturnParam -}}
+        {{.ReturnParam.Type}},
+    {{- end -}}
+    error)
 
 
-{{- /* method body */ -}}
+    {{- /* method body */ -}}
 
-{
-{{template "funcimpl.tmpl" .}}
-}
+    {
+    {{template "funcimpl.tmpl" .}}
+    }
+{{end}}


### PR DESCRIPTION
The generator will use the given filters to only generate the method
implementation of the methods that match one of the filters.

---

The filter to use when generating the methods. This option can be set several times, 
the given filters will be applied in order, and the first that matches will determine the result. The generator
will allow any method by default.

You can use the '!' character to negate a filter. For example, to generate all methods except the 'Add' method:
```
    -method-filter !Add
```

You can also use the '*' character to match any method, so if you want to generate only the 'Add' method, you can do:
```
    -method-filter Add -method-filter !*
```