### PR TITLE
codegen: add parameterless constructor

### DIFF
--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -20,9 +20,11 @@ type genInterface struct {
 }
 
 type genClass struct {
-	Name             string
-	ImplInterfaces   []string
-	StaticInterfaces []genInterface
+	Name                string
+	FullyQualifiedName  string
+	ImplInterfaces      []string
+	StaticInterfaces    []genInterface
+	HasEmptyConstructor bool
 }
 
 type genFunc struct {

--- a/internal/codegen/templates/class.tmpl
+++ b/internal/codegen/templates/class.tmpl
@@ -4,6 +4,16 @@ type {{.Name}} struct {
     {{end}}
 }
 
+{{if .HasEmptyConstructor}}
+func New{{.Name}}() (*{{.Name}}, error) {
+    inspectable, err := ole.RoActivateInstance("{{.FullyQualifiedName}}")
+    if err != nil {
+        return nil, err
+    }
+    return (*{{.Name}})(unsafe.Pointer(inspectable)), nil
+}
+{{end}}
+
 {{range .StaticInterfaces}}
     {{ template "interface.tmpl" .}}
 {{end}}


### PR DESCRIPTION
If the activatable attribute of a runtime class is empty it means that
the runtime class is activatable. So we can add an empty constructor.

---

The docs say that an activatable attribute may contain two type of values:
> - Type: A reference to one of ActivatableAttribute's two .ctors.
>     - Direct Activation: the .ctor taking just the Uint32 version parameter.
>     - Factory activation: the .ctor taking the System.Type factory interface parameter and the Uint32 version parameter.

But I'm not sure where to find that information. What I've seen is that the Activatable Attribute contains an empty record (zero length value) if the class supports direct activation (empty constructor), and that's what we are checking in this PR.