### PR TITLE
codegen: fix function name

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -206,7 +206,7 @@ func (g *generator) validateInterface(typeDef *winmd.TypeDef) error {
 
 // https://docs.microsoft.com/en-us/uwp/winrt-cref/winmd-files#interfaces
 func (g *generator) createGenInterface(typeDef *winmd.TypeDef, requiresActivation bool) (*genInterface, error) {
-	if isParametrizedName(typeDef.TypeName) {
+	if isParameterizedName(typeDef.TypeName) {
 		// parameterized interfaces are not yet supported
 		return nil, fmt.Errorf("could not generate %s.%s, parameterized interfaces are not yet supported", typeDef.TypeNamespace, typeDef.TypeName)
 	}


### PR DESCRIPTION
This was probably an error introduced by the merge made by GitHub.