### PR TITLE
codegen: add support for arrays

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -55,9 +55,10 @@ type {{.Name}} struct {
 	Callback {{.Name}}Callback
 }
 
-type {{.Name}}Callback func({{range .InParams -}}
-    {{.Name}} {{.Type}},
-{{- end}})
+type {{.Name}}Callback func({{- range .InParams -}}
+	{{.GoVarName}} {{ if .IsOut }}*{{ end -}}
+	{{template "variabletype.tmpl" . }},
+{{- end -}})
 
 func New{{.Name}}(callback TypedEventHandlerCallback) *{{.Name}} {
     inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))

--- a/internal/codegen/templates/func.tmpl
+++ b/internal/codegen/templates/func.tmpl
@@ -3,19 +3,20 @@
         (v *{{.FuncOwner}})
     {{- end -}}
 
-    {{funcName .}}
+    {{funcName .}} 
+    
+    {{- /* in params */ -}}
 
-    {{- /* input params */ -}}
-
-    (
+    ( 
     {{- range .InParams -}}
-        {{.Name}} {{.Type}},
+        {{.GoVarName}} {{ if .IsOut }}*{{ end -}}
+        {{template "variabletype.tmpl" . }},
     {{- end -}}
     )
 
     {{- /* return params */ -}}
 
-    ({{ range .ReturnParams}}{{.Type}},{{ end }}error)
+    ( {{range .ReturnParams}}{{template "variabletype.tmpl" . }},{{end}} error )
 
     {{- /* method body */ -}}
 

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -2,12 +2,12 @@
 inspectable, err := ole.RoGetActivationFactory("{{.ExclusiveTo}}", ole.NewGUID(GUID{{.FuncOwner}}))
 if err != nil {
     return {{range .ReturnParams -}}
-        {{.DefaultValue}}, {{end}}err
+        {{.GoDefaultValue}}, {{end}}err
 }
 v := (*{{.FuncOwner}})(unsafe.Pointer(inspectable))
 
 {{end -}}
-{{range .ReturnParams -}}var {{.Name}} {{.Type}}
+{{range .ReturnParams -}}var {{.GoVarName}} {{template "variabletype.tmpl" .}}
 {{end -}}
 hr, _, _ := syscall.SyscallN(
     v.VTable().{{funcName .}},
@@ -17,20 +17,24 @@ hr, _, _ := syscall.SyscallN(
         uintptr(unsafe.Pointer(v)), // this
     {{end -}}
     {{range .InParams -}}
-        {{- if .IsPointer -}}
-            uintptr(unsafe.Pointer({{.Name}})),   // in {{.Name}}
+        {{if .IsOut -}}
+            uintptr(unsafe.Pointer({{.GoVarName}})),   // out {{.GoTypeName}}
+        {{else if .Type.IsPointer -}}
+            uintptr(unsafe.Pointer({{.GoVarName}})),   // in {{.GoTypeName}}
+        {{else if .Type.IsPrimitive -}}
+            uintptr({{.GoVarName}}),   // in {{.GoVarName}}
         {{else -}}
-            uintptr(unsafe.Pointer(&{{.Name}})),   // in {{.Name}}
+            uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoVarName}}
         {{end -}}
     {{end -}}
     {{range .ReturnParams -}}
-        uintptr(unsafe.Pointer(&{{.Name}})), // out {{.Type}}
+        uintptr(unsafe.Pointer(&{{.GoVarName}})), // out {{.GoTypeName}}
     {{end}})
 
 
 if hr != 0 {
-    return {{range .ReturnParams }}{{.DefaultValue}}, {{end}}ole.NewError(hr)
+    return {{range .ReturnParams }}{{.GoDefaultValue}}, {{end}}ole.NewError(hr)
 }
 
-return {{range .ReturnParams }}{{.Name}},{{end}} nil
+return {{range .ReturnParams }}{{.GoVarName}},{{end}} nil
 {{- /* remove trailing white space*/ -}}

--- a/internal/codegen/templates/struct.tmpl
+++ b/internal/codegen/templates/struct.tmpl
@@ -1,5 +1,5 @@
 type {{.Name}} struct {
     {{range .Fields}}
-        {{.Name}} {{.Type}}
+        {{.GoVarName}} {{.GoTypeName}}
     {{end}}
 }

--- a/internal/codegen/templates/variabletype.tmpl
+++ b/internal/codegen/templates/variabletype.tmpl
@@ -1,0 +1,5 @@
+{{if .Type.IsArray}}[]{{end -}}
+{{if .Type.IsPointer}}*{{end -}}
+{{.GoTypeName -}}
+
+{{- /*remove trailing whitespace*/ -}}

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
@@ -73,7 +73,7 @@ func (v *iBluetoothLEAdvertisementReceivedEventArgs) GetAdvertisement() (*Blueto
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetAdvertisement,
 		uintptr(unsafe.Pointer(v)),    // this
-		uintptr(unsafe.Pointer(&out)), // out *BluetoothLEAdvertisement
+		uintptr(unsafe.Pointer(&out)), // out BluetoothLEAdvertisement
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -105,7 +105,7 @@ func (v *iBluetoothLEAdvertisementWatcher) AddReceived(handler *foundation.Typed
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().AddReceived,
 		uintptr(unsafe.Pointer(v)),       // this
-		uintptr(unsafe.Pointer(handler)), // in handler
+		uintptr(unsafe.Pointer(handler)), // in foundation.TypedEventHandler
 		uintptr(unsafe.Pointer(&out)),    // out foundation.EventRegistrationToken
 	)
 
@@ -121,7 +121,7 @@ func (v *iBluetoothLEAdvertisementWatcher) AddStopped(handler *foundation.TypedE
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().AddStopped,
 		uintptr(unsafe.Pointer(v)),       // this
-		uintptr(unsafe.Pointer(handler)), // in handler
+		uintptr(unsafe.Pointer(handler)), // in foundation.TypedEventHandler
 		uintptr(unsafe.Pointer(&out)),    // out foundation.EventRegistrationToken
 	)
 

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -62,8 +62,8 @@ func (v *iBluetoothLEManufacturerData) GetCompanyId() (uint16, error) {
 func (v *iBluetoothLEManufacturerData) SetCompanyId(value uint16) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetCompanyId,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(value),             // in value
 	)
 
 	if hr != 0 {
@@ -78,7 +78,7 @@ func (v *iBluetoothLEManufacturerData) GetData() (*streams.IBuffer, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetData,
 		uintptr(unsafe.Pointer(v)),    // this
-		uintptr(unsafe.Pointer(&out)), // out *streams.IBuffer
+		uintptr(unsafe.Pointer(&out)), // out streams.IBuffer
 	)
 
 	if hr != 0 {
@@ -92,7 +92,7 @@ func (v *iBluetoothLEManufacturerData) SetData(value *streams.IBuffer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetData,
 		uintptr(unsafe.Pointer(v)),     // this
-		uintptr(unsafe.Pointer(value)), // in value
+		uintptr(unsafe.Pointer(value)), // in streams.IBuffer
 	)
 
 	if hr != 0 {
@@ -128,10 +128,10 @@ func Create(companyId uint16, data *streams.IBuffer) (*BluetoothLEManufacturerDa
 	var out *BluetoothLEManufacturerData
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Create,
-		0,                                   // this is a static func, so there's no this
-		uintptr(unsafe.Pointer(&companyId)), // in companyId
-		uintptr(unsafe.Pointer(data)),       // in data
-		uintptr(unsafe.Pointer(&out)),       // out *BluetoothLEManufacturerData
+		0,                             // this is a static func, so there's no this
+		uintptr(companyId),            // in companyId
+		uintptr(unsafe.Pointer(data)), // in streams.IBuffer
+		uintptr(unsafe.Pointer(&out)), // out BluetoothLEManufacturerData
 	)
 
 	if hr != 0 {

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -43,9 +43,9 @@ func (v *IVector) GetAt(index uint32) (unsafe.Pointer, error) {
 	var out unsafe.Pointer
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetAt,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&index)), // in index
-		uintptr(unsafe.Pointer(&out)),   // out unsafe.Pointer
+		uintptr(unsafe.Pointer(v)),    // this
+		uintptr(index),                // in index
+		uintptr(unsafe.Pointer(&out)), // out unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -70,29 +70,28 @@ func (v *IVector) GetSize() (uint32, error) {
 	return out, nil
 }
 
-func (v *IVector) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
-	var index uint32
+func (v *IVector) IndexOf(value unsafe.Pointer, index *uint32) (bool, error) {
 	var out bool
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
 		uintptr(unsafe.Pointer(&value)), // in value
-		uintptr(unsafe.Pointer(&index)), // out uint32
+		uintptr(unsafe.Pointer(index)),  // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)
 
 	if hr != 0 {
-		return 0, false, ole.NewError(hr)
+		return false, ole.NewError(hr)
 	}
 
-	return index, out, nil
+	return out, nil
 }
 
 func (v *IVector) SetAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetAt,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&index)), // in index
+		uintptr(index),                  // in index
 		uintptr(unsafe.Pointer(&value)), // in value
 	)
 
@@ -107,7 +106,7 @@ func (v *IVector) InsertAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().InsertAt,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&index)), // in index
+		uintptr(index),                  // in index
 		uintptr(unsafe.Pointer(&value)), // in value
 	)
 
@@ -121,8 +120,8 @@ func (v *IVector) InsertAt(index uint32, value unsafe.Pointer) error {
 func (v *IVector) RemoveAt(index uint32) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveAt,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&index)), // in index
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(index),             // in index
 	)
 
 	if hr != 0 {
@@ -172,28 +171,29 @@ func (v *IVector) Clear() error {
 	return nil
 }
 
-func (v *IVector) GetMany(startIndex uint32) (unsafe.Pointer, uint32, error) {
-	var items unsafe.Pointer
+func (v *IVector) GetMany(startIndex uint32, itemsSize uint32, items *[]unsafe.Pointer) (uint32, error) {
 	var out uint32
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetMany,
-		uintptr(unsafe.Pointer(v)),           // this
-		uintptr(unsafe.Pointer(&startIndex)), // in startIndex
-		uintptr(unsafe.Pointer(&items)),      // out unsafe.Pointer
-		uintptr(unsafe.Pointer(&out)),        // out uint32
+		uintptr(unsafe.Pointer(v)),     // this
+		uintptr(startIndex),            // in startIndex
+		uintptr(itemsSize),             // in itemsSize
+		uintptr(unsafe.Pointer(items)), // out unsafe.Pointer
+		uintptr(unsafe.Pointer(&out)),  // out uint32
 	)
 
 	if hr != 0 {
-		return nil, 0, ole.NewError(hr)
+		return 0, ole.NewError(hr)
 	}
 
-	return items, out, nil
+	return out, nil
 }
 
-func (v *IVector) ReplaceAll(items unsafe.Pointer) error {
+func (v *IVector) ReplaceAll(itemsSize uint32, items []unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().ReplaceAll,
 		uintptr(unsafe.Pointer(v)),      // this
+		uintptr(itemsSize),              // in itemsSize
 		uintptr(unsafe.Pointer(&items)), // in items
 	)
 

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -42,9 +42,9 @@ func Create(capacity uint32) (*Buffer, error) {
 	var out *Buffer
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Create,
-		0,                                  // this is a static func, so there's no this
-		uintptr(unsafe.Pointer(&capacity)), // in capacity
-		uintptr(unsafe.Pointer(&out)),      // out *Buffer
+		0,                             // this is a static func, so there's no this
+		uintptr(capacity),             // in capacity
+		uintptr(unsafe.Pointer(&out)), // out Buffer
 	)
 
 	if hr != 0 {

--- a/windows/storage/streams/ibuffer.go
+++ b/windows/storage/streams/ibuffer.go
@@ -63,8 +63,8 @@ func (v *IBuffer) GetLength() (uint32, error) {
 func (v *IBuffer) SetLength(value uint32) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetLength,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(value),             // in value
 	)
 
 	if hr != 0 {


### PR DESCRIPTION
This required changing the out parameters to be inputs. This is because
when there's an array output, we don't know the required size of it
inside our function. Check out `IVector.GetMany`.