### PR TITLE
codegen: the delegate needs to know the IDD of the class it implements

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -60,10 +60,10 @@ type {{.Name}}Callback func({{- range .InParams -}}
 	{{template "variabletype.tmpl" . }},
 {{- end -}})
 
-func New{{.Name}}(callback TypedEventHandlerCallback) *{{.Name}} {
+func New{{.Name}}(iid *ole.GUID, callback TypedEventHandlerCallback) *{{.Name}} {
     inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))
     inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_get{{.Name}}Vtbl()))
-    inst.IID = ole.NewGUID(GUID{{.Name}})
+    inst.IID = iid
     inst.Callback = callback
 
     return inst

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -116,6 +116,20 @@ func (v *iBluetoothLEAdvertisementWatcher) AddReceived(handler *foundation.Typed
 	return out, nil
 }
 
+func (v *iBluetoothLEAdvertisementWatcher) RemoveReceived(token foundation.EventRegistrationToken) error {
+	hr, _, _ := syscall.SyscallN(
+		v.VTable().RemoveReceived,
+		uintptr(unsafe.Pointer(v)),      // this
+		uintptr(unsafe.Pointer(&token)), // in token
+	)
+
+	if hr != 0 {
+		return ole.NewError(hr)
+	}
+
+	return nil
+}
+
 func (v *iBluetoothLEAdvertisementWatcher) AddStopped(handler *foundation.TypedEventHandler) (foundation.EventRegistrationToken, error) {
 	var out foundation.EventRegistrationToken
 	hr, _, _ := syscall.SyscallN(
@@ -130,6 +144,20 @@ func (v *iBluetoothLEAdvertisementWatcher) AddStopped(handler *foundation.TypedE
 	}
 
 	return out, nil
+}
+
+func (v *iBluetoothLEAdvertisementWatcher) RemoveStopped(token foundation.EventRegistrationToken) error {
+	hr, _, _ := syscall.SyscallN(
+		v.VTable().RemoveStopped,
+		uintptr(unsafe.Pointer(v)),      // this
+		uintptr(unsafe.Pointer(&token)), // in token
+	)
+
+	if hr != 0 {
+		return ole.NewError(hr)
+	}
+
+	return nil
 }
 
 const GUIDiBluetoothLEAdvertisementWatcher2 string = "01bf26bc-b164-5805-90a3-e8a7997ff225"

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -70,10 +70,10 @@ type TypedEventHandler struct {
 
 type TypedEventHandlerCallback func(sender unsafe.Pointer, args unsafe.Pointer)
 
-func NewTypedEventHandler(callback TypedEventHandlerCallback) *TypedEventHandler {
+func NewTypedEventHandler(iid *ole.GUID, callback TypedEventHandlerCallback) *TypedEventHandler {
 	inst := (*TypedEventHandler)(C.malloc(C.size_t(unsafe.Sizeof(TypedEventHandler{}))))
 	inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_getTypedEventHandlerVtbl()))
-	inst.IID = ole.NewGUID(GUIDTypedEventHandler)
+	inst.IID = iid
 	inst.Callback = callback
 
 	return inst


### PR DESCRIPTION
The TypedEventHandler is a parametrized interface. But we need to know
the GUID of the specialized class (`TypedEventHandler<A>` does not have
the same GUID as `TypedEventHandler<B>`). And these GUIDs are not
included in the *.idl, so we cannot automatically generate them.
According to the docs "these interfaces are generated by the MIDL
compiler, which takes care to specialize each one, and it’s on these
specializations that it attaches the GUID representing the interface
identifier."