### PR TITLE
codegen: pass arrays using a pointer to their first value

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -734,8 +734,9 @@ func (g *generator) getInParameters(curPackage string, typeDef *winmd.TypeDef, m
 			sizeIsOutParam := param.Flags.Out() && e.ByRef
 			genParams = append(genParams, &genParam{
 				callerPackage: curPackage,
-				varName:       cleanReservedWords(param.Name + "Size"),
-				IsOut:         sizeIsOutParam,
+				// Do not change this without also changing the code in the templates
+				varName: cleanReservedWords(param.Name + "Size"),
+				IsOut:   sizeIsOutParam,
 				Type: &genParamType{
 					namespace:    "",
 					name:         "uint32",

--- a/internal/codegen/templates/func.tmpl
+++ b/internal/codegen/templates/func.tmpl
@@ -9,14 +9,18 @@
 
     ( 
     {{- range .InParams -}}
-        {{.GoVarName}} {{ if .IsOut }}*{{ end -}}
-        {{template "variabletype.tmpl" . }},
+        {{/*do not include out parameters, they are used as return values*/ -}}
+        {{ if .IsOut }}{{continue}}{{ end -}}
+        {{.GoVarName}} {{template "variabletype.tmpl" . }},
     {{- end -}}
     )
 
     {{- /* return params */ -}}
 
-    ( {{range .ReturnParams}}{{template "variabletype.tmpl" . }},{{end}} error )
+    ( {{range .InParams -}}
+        {{ if not .IsOut }}{{continue}}{{ end -}}
+        {{template "variabletype.tmpl" . }},{{end -}}
+    {{range .ReturnParams}}{{template "variabletype.tmpl" . }},{{end}} error )
 
     {{- /* method body */ -}}
 

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -7,6 +7,11 @@ if err != nil {
 v := (*{{.FuncOwner}})(unsafe.Pointer(inspectable))
 
 {{end -}}
+{{range .InParams -}}
+    {{ if not .IsOut }}{{continue}}{{ end -}}
+    var {{.GoVarName}} {{template "variabletype.tmpl" . -}}
+    {{if .Type.IsArray}} = make({{template "variabletype.tmpl" . -}}, {{.GoVarName}}Size){{end}}
+{{end -}}
 {{range .ReturnParams -}}var {{.GoVarName}} {{template "variabletype.tmpl" .}}
 {{end -}}
 hr, _, _ := syscall.SyscallN(
@@ -18,7 +23,8 @@ hr, _, _ := syscall.SyscallN(
     {{end -}}
     {{range .InParams -}}
         {{if .IsOut -}}
-            uintptr(unsafe.Pointer({{.GoVarName}})),   // out {{.GoTypeName}}
+            {{/* Arrays need to pass a pointer to their first element */ -}}
+            uintptr(unsafe.Pointer(&{{.GoVarName}}{{if .Type.IsArray }}[0]{{end}})),   // out {{.GoTypeName}}
         {{else if .Type.IsPointer -}}
             uintptr(unsafe.Pointer({{.GoVarName}})),   // in {{.GoTypeName}}
         {{else if .Type.IsPrimitive -}}
@@ -33,8 +39,10 @@ hr, _, _ := syscall.SyscallN(
 
 
 if hr != 0 {
-    return {{range .ReturnParams }}{{.GoDefaultValue}}, {{end}}ole.NewError(hr)
+    return {{range .InParams}}{{if .IsOut}}{{.GoDefaultValue}}, {{end}}{{end -}}
+        {{range .ReturnParams }}{{.GoDefaultValue}}, {{end}}ole.NewError(hr)
 }
 
-return {{range .ReturnParams }}{{.GoVarName}},{{end}} nil
+return {{range .InParams}}{{if .IsOut}}{{.GoVarName}}, {{end}}{{end -}}
+    {{range .ReturnParams }}{{.GoVarName}},{{end}} nil
 {{- /* remove trailing white space*/ -}}

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -70,21 +70,22 @@ func (v *IVector) GetSize() (uint32, error) {
 	return out, nil
 }
 
-func (v *IVector) IndexOf(value unsafe.Pointer, index *uint32) (bool, error) {
+func (v *IVector) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
+	var index uint32
 	var out bool
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
 		uintptr(unsafe.Pointer(&value)), // in value
-		uintptr(unsafe.Pointer(index)),  // out uint32
+		uintptr(unsafe.Pointer(&index)), // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)
 
 	if hr != 0 {
-		return false, ole.NewError(hr)
+		return 0, false, ole.NewError(hr)
 	}
 
-	return out, nil
+	return index, out, nil
 }
 
 func (v *IVector) SetAt(index uint32, value unsafe.Pointer) error {
@@ -171,22 +172,23 @@ func (v *IVector) Clear() error {
 	return nil
 }
 
-func (v *IVector) GetMany(startIndex uint32, itemsSize uint32, items *[]unsafe.Pointer) (uint32, error) {
+func (v *IVector) GetMany(startIndex uint32, itemsSize uint32) ([]unsafe.Pointer, uint32, error) {
+	var items []unsafe.Pointer = make([]unsafe.Pointer, itemsSize)
 	var out uint32
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetMany,
-		uintptr(unsafe.Pointer(v)),     // this
-		uintptr(startIndex),            // in startIndex
-		uintptr(itemsSize),             // in itemsSize
-		uintptr(unsafe.Pointer(items)), // out unsafe.Pointer
-		uintptr(unsafe.Pointer(&out)),  // out uint32
+		uintptr(unsafe.Pointer(v)),         // this
+		uintptr(startIndex),                // in startIndex
+		uintptr(itemsSize),                 // in itemsSize
+		uintptr(unsafe.Pointer(&items[0])), // out unsafe.Pointer
+		uintptr(unsafe.Pointer(&out)),      // out uint32
 	)
 
 	if hr != 0 {
-		return 0, ole.NewError(hr)
+		return nil, 0, ole.NewError(hr)
 	}
 
-	return out, nil
+	return items, out, nil
 }
 
 func (v *IVector) ReplaceAll(itemsSize uint32, items []unsafe.Pointer) error {

--- a/windows/storage/streams/idatareader.go
+++ b/windows/storage/streams/idatareader.go
@@ -53,17 +53,18 @@ func (v *IDataReader) VTable() *IDataReaderVtbl {
 	return (*IDataReaderVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func (v *IDataReader) ReadBytes(valueSize uint32, value *[]uint8) error {
+func (v *IDataReader) ReadBytes(valueSize uint32) ([]uint8, error) {
+	var value []uint8 = make([]uint8, valueSize)
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().ReadBytes,
-		uintptr(unsafe.Pointer(v)),     // this
-		uintptr(valueSize),             // in valueSize
-		uintptr(unsafe.Pointer(value)), // out uint8
+		uintptr(unsafe.Pointer(v)),         // this
+		uintptr(valueSize),                 // in valueSize
+		uintptr(unsafe.Pointer(&value[0])), // out uint8
 	)
 
 	if hr != 0 {
-		return ole.NewError(hr)
+		return nil, ole.NewError(hr)
 	}
 
-	return nil
+	return value, nil
 }


### PR DESCRIPTION
I also changed the out parameters to be return values instead of pointer
inputs. That was changed because we did not know how to initialize
arrays, but now we know that a variable will always be passed for the
size.