### PR TITLE
codegen: add type signatures and parameterized GUID generator

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,12 +7,16 @@ require (
 	github.com/go-kit/log v0.2.1
 	github.com/go-ole/go-ole v1.2.6
 	github.com/peterbourgon/ff/v3 v3.1.2
+	github.com/stretchr/testify v1.7.5
 	github.com/tdakkota/win32metadata v0.1.0
 	golang.org/x/tools v0.1.11
 )
 
 require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
 	golang.org/x/sys v0.0.0-20220624220833-87e55d714810 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -50,6 +50,7 @@ golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.1.11 h1:loJ25fNOEhSXfHrpoGj91eCUThwdNX6u24rO1xnNteY=
 golang.org/x/tools v0.1.11/go.mod h1:SgwaegtQh8clINPpECJMqnxLv9I09HLqnW3RMqW0CA4=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -46,9 +46,10 @@ func (g *genData) ComputeImports(typeDef *winmd.TypeDef) {
 }
 
 type genInterface struct {
-	Name  string
-	GUID  string
-	Funcs []genFunc
+	Name      string
+	GUID      string
+	Signature string
+	Funcs     []genFunc
 }
 
 func (g *genInterface) GetRequiredImports() []genImport {
@@ -61,6 +62,7 @@ func (g *genInterface) GetRequiredImports() []genImport {
 
 type genClass struct {
 	Name                string
+	Signature           string
 	RequiresImports     []genImport
 	FullyQualifiedName  string
 	ImplInterfaces      []string
@@ -85,14 +87,16 @@ func (g *genClass) GetRequiredImports() []genImport {
 type genDelegate struct {
 	Name        string
 	GUID        string
+	Signature   string
 	InParams    []*genParam
 	ReturnParam *genParam // this may be nil
 }
 
 type genEnum struct {
-	Name   string
-	Type   string
-	Values []genEnumValue
+	Name      string
+	Type      string
+	Signature string
+	Values    []genEnumValue
 }
 type genEnumValue struct {
 	Name  string
@@ -193,8 +197,9 @@ func (g *genParam) GoDefaultValue() string {
 }
 
 type genStruct struct {
-	Name   string
-	Fields []*genParam
+	Name      string
+	Signature string
+	Fields    []*genParam
 }
 
 //go:embed templates/*

--- a/internal/codegen/templates/class.tmpl
+++ b/internal/codegen/templates/class.tmpl
@@ -1,3 +1,5 @@
+const Signature{{.Name}} string = "{{.Signature}}"
+
 type {{.Name}} struct {
     {{range .ImplInterfaces}}
         {{.}}

--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -48,6 +48,7 @@ const {{.Name}}Vtbl_t * winrt_get{{.Name}}Vtbl(void) {
 import "C"
 
 const GUID{{.Name}} string = "{{.GUID}}"
+const Signature{{.Name}} string = "{{.Signature}}"
 
 type {{.Name}} struct {
 	ole.IUnknown

--- a/internal/codegen/templates/enum.tmpl
+++ b/internal/codegen/templates/enum.tmpl
@@ -1,4 +1,5 @@
 type {{.Name}} {{.Type}}
+const Signature{{.Name}} string = "{{.Signature}}"
 
 const ({{range .Values}}
     {{.Name}} {{$.Name}} = {{.Value}}{{end}}

--- a/internal/codegen/templates/interface.tmpl
+++ b/internal/codegen/templates/interface.tmpl
@@ -1,4 +1,5 @@
 const GUID{{.Name}} string = "{{.GUID}}"
+const Signature{{.Name}} string = "{{.Signature}}"
 
 type {{.Name}} struct {
     ole.IInspectable

--- a/internal/codegen/templates/struct.tmpl
+++ b/internal/codegen/templates/struct.tmpl
@@ -1,3 +1,5 @@
+const Signature{{.Name}} string = "{{.Signature}}"
+
 type {{.Name}} struct {
     {{range .Fields}}
         {{.GoVarName}} {{.GoTypeName}}

--- a/signature.go
+++ b/signature.go
@@ -1,0 +1,70 @@
+package winrt
+
+import (
+	"crypto/sha1" // #nosec this is not used for security purposes
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/go-ole/go-ole"
+)
+
+// Primitive types signatures
+const (
+	SignatureUInt8   = "u1"
+	SignatureUInt16  = "u2"
+	SignatureUInt32  = "u4"
+	SignatureUInt64  = "u8"
+	SignatureInt8    = "i1"
+	SignatureInt16   = "i2"
+	SignatureInt32   = "i4"
+	SignatureInt64   = "i8"
+	SignatureFloat32 = "f4"
+	SignatureFloat64 = "f8"
+	SignatureBool    = "b1"
+	SignatureChar    = "c2"
+	SignatureString  = "string"
+	SignatureGUID    = "g16"
+)
+
+// ParameterizedInstanceGUID creates a `GUID` for a "generic" WinRT delegate or interface. This was ported from the RUST implementation
+// of WinRT, checkout for the source code:
+// https://github.com/microsoft/windows-rs/blob/68576f37df4c02f09bc6e4dd1ed8ed8844c6eb9c/crates/libs/windows/src/core/guid.rs#L44
+//
+// Checkout the following link for documentation on how the signatures are generated:
+// https://docs.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#guid-generation-for-parameterized-types
+func ParameterizedInstanceGUID(baseGUID string, signatures ...string) string {
+	res := fmt.Sprintf("pinterface({%s};%s)", baseGUID, strings.Join(signatures, ";"))
+	return guidFromSignature(res)
+}
+
+func guidFromSignature(signature string) string {
+	// base wrt_pinterface_namespace => 11f47ad5-7b73-42c0-abae-878b1e16adee
+	data := []byte{0x11, 0xf4, 0x7a, 0xd5, 0x7b, 0x73, 0x42, 0xc0, 0xab, 0xae, 0x87, 0x8b, 0x1e, 0x16, 0xad, 0xee}
+
+	data = append(data, []byte(signature)...)
+
+	hash := sha1.New() // #nosec this is not used for security purposes
+	if _, err := hash.Write(data); err != nil {
+		return "_ERROR_"
+	}
+
+	bytes := hash.Sum(nil)
+	first := binary.BigEndian.Uint32(bytes[0:4])
+	second := binary.BigEndian.Uint16(bytes[4:6])
+	third := binary.BigEndian.Uint16(bytes[6:8])
+	third = (third & 0x0fff) | (5 << 12)
+	fourth := (bytes[8] & 0x3f) | 0x80
+
+	guid := guidFromValues(first, second, third, [8]byte{fourth, bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]})
+	return guid.String()
+}
+
+func guidFromValues(first uint32, second, third uint16, rest [8]byte) ole.GUID {
+	return ole.GUID{
+		Data1: first,
+		Data2: second,
+		Data3: third,
+		Data4: rest,
+	}
+}

--- a/signature_test.go
+++ b/signature_test.go
@@ -1,0 +1,31 @@
+package winrt
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that we can create a `GUID` for a "generic" WinRT type.
+const (
+	guidTypedEventHandler                                    = "9de1c534-6ae1-11e0-84e1-18a905bcc53f"
+	signatureBluetoothLEAdvertisementWatcher                 = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher;{a6ac336f-f3d3-4297-8d6c-c81ea6623f40})"
+	signatureBluetoothLEAdvertisementReceivedEventArgs       = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs;{27987ddf-e596-41be-8d43-9e6731d4a913})"
+	signatureBluetoothLEAdvertisementWatcherStoppedEventArgs = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStoppedEventArgs;{dd40f84d-e7b9-43e3-9c04-0685d085fd8c})"
+)
+
+// TypedEventHandler<IBluetoothLEAdvertisementWatcher, IBluetoothLEAdvertisementReceivedEventArgs>
+func TestParametrizedReceivedEvent(t *testing.T) {
+	expected := "{90EB4ECA-D465-5EA0-A61C-033C8C5ECEF2}"
+	guid := ParameterizedInstanceGUID(guidTypedEventHandler, signatureBluetoothLEAdvertisementWatcher, signatureBluetoothLEAdvertisementReceivedEventArgs)
+
+	assert.Equal(t, expected, guid)
+}
+
+// TypedEventHandler<IBluetoothLEAdvertisementWatcher, IBluetoothLEAdvertisementReceivedEventArgs>
+func TestParametrizedStoppedEvent(t *testing.T) {
+	expected := "{9936A4DB-DC99-55C3-9E9B-BF4854BD9EAB}"
+	guid := ParameterizedInstanceGUID(guidTypedEventHandler, signatureBluetoothLEAdvertisementWatcher, signatureBluetoothLEAdvertisementWatcherStoppedEventArgs)
+
+	assert.Equal(t, expected, guid)
+}

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
@@ -13,6 +13,8 @@ import (
 	"github.com/saltosystems/winrt-go/windows/foundation/collections"
 )
 
+const SignatureBluetoothLEAdvertisement string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement;{066fb2b7-33d1-4e7d-8367-cf81d0f79653})"
+
 type BluetoothLEAdvertisement struct {
 	iBluetoothLEAdvertisement
 }
@@ -26,6 +28,7 @@ func NewBluetoothLEAdvertisement() (*BluetoothLEAdvertisement, error) {
 }
 
 const GUIDiBluetoothLEAdvertisement string = "066fb2b7-33d1-4e7d-8367-cf81d0f79653"
+const SignatureiBluetoothLEAdvertisement string = "{066fb2b7-33d1-4e7d-8367-cf81d0f79653}"
 
 type iBluetoothLEAdvertisement struct {
 	ole.IInspectable

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+const SignatureBluetoothLEAdvertisementDataSection string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection;{d7213314-3a43-40f9-b6f0-92bfefc34ae3})"
+
 type BluetoothLEAdvertisementDataSection struct {
 	iBluetoothLEAdvertisementDataSection
 }
@@ -25,6 +27,7 @@ func NewBluetoothLEAdvertisementDataSection() (*BluetoothLEAdvertisementDataSect
 }
 
 const GUIDiBluetoothLEAdvertisementDataSection string = "d7213314-3a43-40f9-b6f0-92bfefc34ae3"
+const SignatureiBluetoothLEAdvertisementDataSection string = "{d7213314-3a43-40f9-b6f0-92bfefc34ae3}"
 
 type iBluetoothLEAdvertisementDataSection struct {
 	ole.IInspectable

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
@@ -12,6 +12,8 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+const SignatureBluetoothLEAdvertisementReceivedEventArgs string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs;{27987ddf-e596-41be-8d43-9e6731d4a913})"
+
 type BluetoothLEAdvertisementReceivedEventArgs struct {
 	iBluetoothLEAdvertisementReceivedEventArgs
 
@@ -19,6 +21,7 @@ type BluetoothLEAdvertisementReceivedEventArgs struct {
 }
 
 const GUIDiBluetoothLEAdvertisementReceivedEventArgs string = "27987ddf-e596-41be-8d43-9e6731d4a913"
+const SignatureiBluetoothLEAdvertisementReceivedEventArgs string = "{27987ddf-e596-41be-8d43-9e6731d4a913}"
 
 type iBluetoothLEAdvertisementReceivedEventArgs struct {
 	ole.IInspectable
@@ -84,6 +87,7 @@ func (v *iBluetoothLEAdvertisementReceivedEventArgs) GetAdvertisement() (*Blueto
 }
 
 const GUIDiBluetoothLEAdvertisementReceivedEventArgs2 string = "12d9c87b-0399-5f0e-a348-53b02b6b162e"
+const SignatureiBluetoothLEAdvertisementReceivedEventArgs2 string = "{12d9c87b-0399-5f0e-a348-53b02b6b162e}"
 
 type iBluetoothLEAdvertisementReceivedEventArgs2 struct {
 	ole.IInspectable

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -13,6 +13,8 @@ import (
 	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
+const SignatureBluetoothLEAdvertisementWatcher string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher;{a6ac336f-f3d3-4297-8d6c-c81ea6623f40})"
+
 type BluetoothLEAdvertisementWatcher struct {
 	iBluetoothLEAdvertisementWatcher
 
@@ -28,6 +30,7 @@ func NewBluetoothLEAdvertisementWatcher() (*BluetoothLEAdvertisementWatcher, err
 }
 
 const GUIDiBluetoothLEAdvertisementWatcher string = "a6ac336f-f3d3-4297-8d6c-c81ea6623f40"
+const SignatureiBluetoothLEAdvertisementWatcher string = "{a6ac336f-f3d3-4297-8d6c-c81ea6623f40}"
 
 type iBluetoothLEAdvertisementWatcher struct {
 	ole.IInspectable
@@ -161,6 +164,7 @@ func (v *iBluetoothLEAdvertisementWatcher) RemoveStopped(token foundation.EventR
 }
 
 const GUIDiBluetoothLEAdvertisementWatcher2 string = "01bf26bc-b164-5805-90a3-e8a7997ff225"
+const SignatureiBluetoothLEAdvertisementWatcher2 string = "{01bf26bc-b164-5805-90a3-e8a7997ff225}"
 
 type iBluetoothLEAdvertisementWatcher2 struct {
 	ole.IInspectable

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstatus.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstatus.go
@@ -7,6 +7,8 @@ package advertisement
 
 type BluetoothLEAdvertisementWatcherStatus int32
 
+const SignatureBluetoothLEAdvertisementWatcherStatus string = "enum(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStatus;i4)"
+
 const (
 	BluetoothLEAdvertisementWatcherStatusCreated  BluetoothLEAdvertisementWatcherStatus = 0
 	BluetoothLEAdvertisementWatcherStatusStarted  BluetoothLEAdvertisementWatcherStatus = 1

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
@@ -11,11 +11,14 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+const SignatureBluetoothLEAdvertisementWatcherStoppedEventArgs string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStoppedEventArgs;{dd40f84d-e7b9-43e3-9c04-0685d085fd8c})"
+
 type BluetoothLEAdvertisementWatcherStoppedEventArgs struct {
 	iBluetoothLEAdvertisementWatcherStoppedEventArgs
 }
 
 const GUIDiBluetoothLEAdvertisementWatcherStoppedEventArgs string = "dd40f84d-e7b9-43e3-9c04-0685d085fd8c"
+const SignatureiBluetoothLEAdvertisementWatcherStoppedEventArgs string = "{dd40f84d-e7b9-43e3-9c04-0685d085fd8c}"
 
 type iBluetoothLEAdvertisementWatcherStoppedEventArgs struct {
 	ole.IInspectable

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -13,6 +13,8 @@ import (
 	"github.com/saltosystems/winrt-go/windows/storage/streams"
 )
 
+const SignatureBluetoothLEManufacturerData string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData;{912dba18-6963-4533-b061-4694dafb34e5})"
+
 type BluetoothLEManufacturerData struct {
 	iBluetoothLEManufacturerData
 }
@@ -26,6 +28,7 @@ func NewBluetoothLEManufacturerData() (*BluetoothLEManufacturerData, error) {
 }
 
 const GUIDiBluetoothLEManufacturerData string = "912dba18-6963-4533-b061-4694dafb34e5"
+const SignatureiBluetoothLEManufacturerData string = "{912dba18-6963-4533-b061-4694dafb34e5}"
 
 type iBluetoothLEManufacturerData struct {
 	ole.IInspectable
@@ -103,6 +106,7 @@ func (v *iBluetoothLEManufacturerData) SetData(value *streams.IBuffer) error {
 }
 
 const GUIDiBluetoothLEManufacturerDataFactory string = "c09b39f8-319a-441e-8de5-66a81e877a6c"
+const SignatureiBluetoothLEManufacturerDataFactory string = "{c09b39f8-319a-441e-8de5-66a81e877a6c}"
 
 type iBluetoothLEManufacturerDataFactory struct {
 	ole.IInspectable

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -13,6 +13,7 @@ import (
 )
 
 const GUIDIVector string = "913337e9-11a1-4345-a3a2-4e7f956e222d"
+const SignatureIVector string = "{913337e9-11a1-4345-a3a2-4e7f956e222d}"
 
 type IVector struct {
 	ole.IInspectable

--- a/windows/foundation/eventregistrationtoken.go
+++ b/windows/foundation/eventregistrationtoken.go
@@ -5,6 +5,8 @@
 //nolint
 package foundation
 
+const SignatureEventRegistrationToken string = "struct(Windows.Foundation.EventRegistrationToken;i8)"
+
 type EventRegistrationToken struct {
 	Value int64
 }

--- a/windows/foundation/iclosable.go
+++ b/windows/foundation/iclosable.go
@@ -13,6 +13,7 @@ import (
 )
 
 const GUIDIClosable string = "30d5a829-7fa4-4026-83bb-d75bae4ea99e"
+const SignatureIClosable string = "{30d5a829-7fa4-4026-83bb-d75bae4ea99e}"
 
 type IClosable struct {
 	ole.IInspectable

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -61,6 +61,7 @@ const TypedEventHandlerVtbl_t * winrt_getTypedEventHandlerVtbl(void) {
 import "C"
 
 const GUIDTypedEventHandler string = "9de1c534-6ae1-11e0-84e1-18a905bcc53f"
+const SignatureTypedEventHandler string = "delegate({9de1c534-6ae1-11e0-84e1-18a905bcc53f})"
 
 type TypedEventHandler struct {
 	ole.IUnknown

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -12,11 +12,14 @@ import (
 	"github.com/go-ole/go-ole"
 )
 
+const SignatureBuffer string = "rc(Windows.Storage.Streams.Buffer;{905a0fe0-bc53-11df-8c49-001e4fc686da})"
+
 type Buffer struct {
 	IBuffer
 }
 
 const GUIDiBufferFactory string = "71af914d-c10f-484b-bc50-14bc623b3a27"
+const SignatureiBufferFactory string = "{71af914d-c10f-484b-bc50-14bc623b3a27}"
 
 type iBufferFactory struct {
 	ole.IInspectable

--- a/windows/storage/streams/datareader.go
+++ b/windows/storage/streams/datareader.go
@@ -13,6 +13,8 @@ import (
 	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
+const SignatureDataReader string = "rc(Windows.Storage.Streams.DataReader;{e2b50029-b4c1-4314-a4b8-fb813a2f275e})"
+
 type DataReader struct {
 	IDataReader
 
@@ -20,6 +22,7 @@ type DataReader struct {
 }
 
 const GUIDiDataReaderStatics string = "11fcbfc8-f93a-471b-b121-f379e349313c"
+const SignatureiDataReaderStatics string = "{11fcbfc8-f93a-471b-b121-f379e349313c}"
 
 type iDataReaderStatics struct {
 	ole.IInspectable

--- a/windows/storage/streams/ibuffer.go
+++ b/windows/storage/streams/ibuffer.go
@@ -13,6 +13,7 @@ import (
 )
 
 const GUIDIBuffer string = "905a0fe0-bc53-11df-8c49-001e4fc686da"
+const SignatureIBuffer string = "{905a0fe0-bc53-11df-8c49-001e4fc686da}"
 
 type IBuffer struct {
 	ole.IInspectable

--- a/windows/storage/streams/idatareader.go
+++ b/windows/storage/streams/idatareader.go
@@ -13,6 +13,7 @@ import (
 )
 
 const GUIDIDataReader string = "e2b50029-b4c1-4314-a4b8-fb813a2f275e"
+const SignatureIDataReader string = "{e2b50029-b4c1-4314-a4b8-fb813a2f275e}"
 
 type IDataReader struct {
 	ole.IInspectable


### PR DESCRIPTION
This is required because some use cases require knowing the GUID of a
parameterized instance. This GUID changes based on the parameters used:
`TypedEventHandler<IBluetooth, ReceivedEvent>` won't have the same GUID
as `TypedEventHandler<IBluetooth, StoppedEvent>`.