### PR TITLE
codegen/delegate: add in parameters to invoke and pass them to callback

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -56,9 +56,8 @@ type {{.Name}} struct {
 	Callback {{.Name}}Callback
 }
 
-type {{.Name}}Callback func({{- range .InParams -}}
-	{{.GoVarName}} {{ if .IsOut }}*{{ end -}}
-	{{template "variabletype.tmpl" . }},
+type {{.Name}}Callback func(instance *{{.Name}},{{- range .InParams -}}
+	{{.GoVarName}} {{template "variabletype.tmpl" . }},
 {{- end -}})
 
 func New{{.Name}}(iid *ole.GUID, callback TypedEventHandlerCallback) *{{.Name}} {

--- a/internal/codegen/templates/delegate_exports.tmpl
+++ b/internal/codegen/templates/delegate_exports.tmpl
@@ -24,9 +24,9 @@ func winrt_{{.Name}}_QueryInterface(instancePtr, iidPtr unsafe.Pointer, ppvObjec
 }
 
 //export winrt_{{.Name}}_Invoke
-func winrt_{{.Name}}_Invoke(instancePtr, senderPtr, argsPtr unsafe.Pointer) uintptr {
+func winrt_{{.Name}}_Invoke(instancePtr {{range .InParams}},{{.GoVarName}}Ptr{{end}} unsafe.Pointer) uintptr {
 	// See the quote above.
 	instance := (*{{.Name}})(instancePtr)
-	instance.Callback(instancePtr, argsPtr)
+	instance.Callback(instance, {{range .InParams}}{{.GoVarName}}Ptr,{{end}})
 	return ole.S_OK
 }

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -69,7 +69,7 @@ type TypedEventHandler struct {
 	Callback TypedEventHandlerCallback
 }
 
-type TypedEventHandlerCallback func(sender unsafe.Pointer, args unsafe.Pointer)
+type TypedEventHandlerCallback func(instance *TypedEventHandler, sender unsafe.Pointer, args unsafe.Pointer)
 
 func NewTypedEventHandler(iid *ole.GUID, callback TypedEventHandlerCallback) *TypedEventHandler {
 	inst := (*TypedEventHandler)(C.malloc(C.size_t(unsafe.Sizeof(TypedEventHandler{}))))

--- a/windows/foundation/typedeventhandler_exports.go
+++ b/windows/foundation/typedeventhandler_exports.go
@@ -40,6 +40,6 @@ func winrt_TypedEventHandler_QueryInterface(instancePtr, iidPtr unsafe.Pointer, 
 func winrt_TypedEventHandler_Invoke(instancePtr, senderPtr, argsPtr unsafe.Pointer) uintptr {
 	// See the quote above.
 	instance := (*TypedEventHandler)(instancePtr)
-	instance.Callback(instancePtr, argsPtr)
+	instance.Callback(instance, senderPtr, argsPtr)
 	return ole.S_OK
 }


### PR DESCRIPTION
These parameters were previously hardcoded to match the
`TypedEventHandler` delegate.