### PR TITLE
codegen: call implemented interface methods using QueryInterface

### DIFF
--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -16,17 +16,17 @@ type genDataFile struct {
 type genData struct {
 	Package         string
 	Imports         []string
-	Classes         []genClass
-	Enums           []genEnum
-	Interfaces      []genInterface
-	Structs         []genStruct
-	Delegates       []genDelegate
-	DelegateExports []genDelegate
+	Classes         []*genClass
+	Enums           []*genEnum
+	Interfaces      []*genInterface
+	Structs         []*genStruct
+	Delegates       []*genDelegate
+	DelegateExports []*genDelegate
 }
 
 func (g *genData) ComputeImports(typeDef *winmd.TypeDef) {
 	// gather all imports
-	imports := make([]genImport, 0)
+	imports := make([]*genImport, 0)
 	if g.Classes != nil {
 		for _, c := range g.Classes {
 			imports = append(imports, c.GetRequiredImports()...)
@@ -49,11 +49,11 @@ type genInterface struct {
 	Name      string
 	GUID      string
 	Signature string
-	Funcs     []genFunc
+	Funcs     []*genFunc
 }
 
-func (g *genInterface) GetRequiredImports() []genImport {
-	imports := make([]genImport, 0)
+func (g *genInterface) GetRequiredImports() []*genImport {
+	imports := make([]*genImport, 0)
 	for _, f := range g.Funcs {
 		imports = append(imports, f.RequiresImports...)
 	}
@@ -63,15 +63,15 @@ func (g *genInterface) GetRequiredImports() []genImport {
 type genClass struct {
 	Name                string
 	Signature           string
-	RequiresImports     []genImport
+	RequiresImports     []*genImport
 	FullyQualifiedName  string
-	ImplInterfaces      []string
-	ExclusiveInterfaces []genInterface
+	ImplInterfaces      []*genInterface
+	ExclusiveInterfaces []*genInterface
 	HasEmptyConstructor bool
 }
 
-func (g *genClass) GetRequiredImports() []genImport {
-	imports := make([]genImport, 0)
+func (g *genClass) GetRequiredImports() []*genImport {
+	imports := make([]*genImport, 0)
 	if g.RequiresImports != nil {
 		imports = append(imports, g.RequiresImports...)
 	}
@@ -96,7 +96,7 @@ type genEnum struct {
 	Name      string
 	Type      string
 	Signature string
-	Values    []genEnumValue
+	Values    []*genEnumValue
 }
 type genEnumValue struct {
 	Name  string
@@ -105,7 +105,7 @@ type genEnumValue struct {
 
 type genFunc struct {
 	Name            string
-	RequiresImports []genImport
+	RequiresImports []*genImport
 	Implement       bool
 	FuncOwner       string
 	InParams        []*genParam
@@ -113,9 +113,10 @@ type genFunc struct {
 
 	// ExclusiveTo is the name of the class that this function is exclusive to.
 	// The funcion will be called statically using the RoGetActivationFactory function.
-	ExclusiveTo string
-
+	ExclusiveTo        string
 	RequiresActivation bool
+
+	InheritedFrom winmd.QualifiedID
 }
 
 type genImport struct {

--- a/internal/codegen/templates/class.tmpl
+++ b/internal/codegen/templates/class.tmpl
@@ -1,9 +1,7 @@
 const Signature{{.Name}} string = "{{.Signature}}"
 
 type {{.Name}} struct {
-    {{range .ImplInterfaces}}
-        {{.}}
-    {{end}}
+    ole.IUnknown
 }
 
 {{if .HasEmptyConstructor}}
@@ -14,6 +12,45 @@ func New{{.Name}}() (*{{.Name}}, error) {
     }
     return (*{{.Name}})(unsafe.Pointer(inspectable)), nil
 }
+{{end}}
+
+{{$owner := .Name}}
+{{range .ImplInterfaces}}
+    {{range .Funcs}}
+        {{if not .Implement}}{{continue}}{{end}}
+        func (impl *{{$owner}}) {{funcName .}} (
+            {{- range .InParams -}}
+                {{/*do not include out parameters, they are used as return values*/ -}}
+                {{ if .IsOut }}{{continue}}{{ end -}}
+                {{.GoVarName}} {{template "variabletype.tmpl" . }},
+            {{- end -}}
+        )
+
+        {{- /* return params */ -}}
+
+        ( {{range .InParams -}}
+            {{ if not .IsOut }}{{continue}}{{ end -}}
+            {{template "variabletype.tmpl" . }},{{end -}}
+        {{range .ReturnParams}}{{template "variabletype.tmpl" . }},{{end}} error )
+
+        {{- /* method body */ -}}
+
+        {
+            itf := impl.MustQueryInterface(ole.NewGUID({{if .InheritedFrom.Namespace}}{{.InheritedFrom.Namespace}}.{{end}}GUID{{.InheritedFrom.Name}}))
+            defer itf.Release()
+            v := (*{{if .InheritedFrom.Namespace}}{{.InheritedFrom.Namespace}}.{{end}}{{.InheritedFrom.Name}})(unsafe.Pointer(itf))
+            return v.{{funcName . -}}
+            (
+                {{- range .InParams -}}
+                    {{if .IsOut -}}
+                        {{continue -}}
+                    {{end -}}
+                    {{.GoVarName -}}
+                    ,
+                {{- end -}}
+            )
+        }
+    {{end}}
 {{end}}
 
 {{range .ExclusiveInterfaces}}

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
@@ -16,7 +16,7 @@ import (
 const SignatureBluetoothLEAdvertisement string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement;{066fb2b7-33d1-4e7d-8367-cf81d0f79653})"
 
 type BluetoothLEAdvertisement struct {
-	iBluetoothLEAdvertisement
+	ole.IUnknown
 }
 
 func NewBluetoothLEAdvertisement() (*BluetoothLEAdvertisement, error) {
@@ -25,6 +25,34 @@ func NewBluetoothLEAdvertisement() (*BluetoothLEAdvertisement, error) {
 		return nil, err
 	}
 	return (*BluetoothLEAdvertisement)(unsafe.Pointer(inspectable)), nil
+}
+
+func (impl *BluetoothLEAdvertisement) GetLocalName() (string, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisement))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisement)(unsafe.Pointer(itf))
+	return v.GetLocalName()
+}
+
+func (impl *BluetoothLEAdvertisement) GetServiceUuids() (*collections.IVector, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisement))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisement)(unsafe.Pointer(itf))
+	return v.GetServiceUuids()
+}
+
+func (impl *BluetoothLEAdvertisement) GetManufacturerData() (*collections.IVector, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisement))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisement)(unsafe.Pointer(itf))
+	return v.GetManufacturerData()
+}
+
+func (impl *BluetoothLEAdvertisement) GetDataSections() (*collections.IVector, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisement))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisement)(unsafe.Pointer(itf))
+	return v.GetDataSections()
 }
 
 const GUIDiBluetoothLEAdvertisement string = "066fb2b7-33d1-4e7d-8367-cf81d0f79653"

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
@@ -15,7 +15,7 @@ import (
 const SignatureBluetoothLEAdvertisementDataSection string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection;{d7213314-3a43-40f9-b6f0-92bfefc34ae3})"
 
 type BluetoothLEAdvertisementDataSection struct {
-	iBluetoothLEAdvertisementDataSection
+	ole.IUnknown
 }
 
 func NewBluetoothLEAdvertisementDataSection() (*BluetoothLEAdvertisementDataSection, error) {
@@ -24,6 +24,13 @@ func NewBluetoothLEAdvertisementDataSection() (*BluetoothLEAdvertisementDataSect
 		return nil, err
 	}
 	return (*BluetoothLEAdvertisementDataSection)(unsafe.Pointer(inspectable)), nil
+}
+
+func (impl *BluetoothLEAdvertisementDataSection) GetDataType() (uint8, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementDataSection))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementDataSection)(unsafe.Pointer(itf))
+	return v.GetDataType()
 }
 
 const GUIDiBluetoothLEAdvertisementDataSection string = "d7213314-3a43-40f9-b6f0-92bfefc34ae3"

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
@@ -15,9 +15,28 @@ import (
 const SignatureBluetoothLEAdvertisementReceivedEventArgs string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementReceivedEventArgs;{27987ddf-e596-41be-8d43-9e6731d4a913})"
 
 type BluetoothLEAdvertisementReceivedEventArgs struct {
-	iBluetoothLEAdvertisementReceivedEventArgs
+	ole.IUnknown
+}
 
-	iBluetoothLEAdvertisementReceivedEventArgs2
+func (impl *BluetoothLEAdvertisementReceivedEventArgs) GetRawSignalStrengthInDBm() (int16, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementReceivedEventArgs))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementReceivedEventArgs)(unsafe.Pointer(itf))
+	return v.GetRawSignalStrengthInDBm()
+}
+
+func (impl *BluetoothLEAdvertisementReceivedEventArgs) GetBluetoothAddress() (uint64, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementReceivedEventArgs))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementReceivedEventArgs)(unsafe.Pointer(itf))
+	return v.GetBluetoothAddress()
+}
+
+func (impl *BluetoothLEAdvertisementReceivedEventArgs) GetAdvertisement() (*BluetoothLEAdvertisement, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementReceivedEventArgs))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementReceivedEventArgs)(unsafe.Pointer(itf))
+	return v.GetAdvertisement()
 }
 
 const GUIDiBluetoothLEAdvertisementReceivedEventArgs string = "27987ddf-e596-41be-8d43-9e6731d4a913"

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -16,9 +16,7 @@ import (
 const SignatureBluetoothLEAdvertisementWatcher string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcher;{a6ac336f-f3d3-4297-8d6c-c81ea6623f40})"
 
 type BluetoothLEAdvertisementWatcher struct {
-	iBluetoothLEAdvertisementWatcher
-
-	iBluetoothLEAdvertisementWatcher2
+	ole.IUnknown
 }
 
 func NewBluetoothLEAdvertisementWatcher() (*BluetoothLEAdvertisementWatcher, error) {
@@ -27,6 +25,55 @@ func NewBluetoothLEAdvertisementWatcher() (*BluetoothLEAdvertisementWatcher, err
 		return nil, err
 	}
 	return (*BluetoothLEAdvertisementWatcher)(unsafe.Pointer(inspectable)), nil
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) GetStatus() (BluetoothLEAdvertisementWatcherStatus, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.GetStatus()
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) Start() error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.Start()
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) Stop() error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.Stop()
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) AddReceived(handler *foundation.TypedEventHandler) (foundation.EventRegistrationToken, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.AddReceived(handler)
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) RemoveReceived(token foundation.EventRegistrationToken) error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.RemoveReceived(token)
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) AddStopped(handler *foundation.TypedEventHandler) (foundation.EventRegistrationToken, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.AddStopped(handler)
+}
+
+func (impl *BluetoothLEAdvertisementWatcher) RemoveStopped(token foundation.EventRegistrationToken) error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementWatcher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementWatcher)(unsafe.Pointer(itf))
+	return v.RemoveStopped(token)
 }
 
 const GUIDiBluetoothLEAdvertisementWatcher string = "a6ac336f-f3d3-4297-8d6c-c81ea6623f40"

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
@@ -14,7 +14,7 @@ import (
 const SignatureBluetoothLEAdvertisementWatcherStoppedEventArgs string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementWatcherStoppedEventArgs;{dd40f84d-e7b9-43e3-9c04-0685d085fd8c})"
 
 type BluetoothLEAdvertisementWatcherStoppedEventArgs struct {
-	iBluetoothLEAdvertisementWatcherStoppedEventArgs
+	ole.IUnknown
 }
 
 const GUIDiBluetoothLEAdvertisementWatcherStoppedEventArgs string = "dd40f84d-e7b9-43e3-9c04-0685d085fd8c"

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -16,7 +16,7 @@ import (
 const SignatureBluetoothLEManufacturerData string = "rc(Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData;{912dba18-6963-4533-b061-4694dafb34e5})"
 
 type BluetoothLEManufacturerData struct {
-	iBluetoothLEManufacturerData
+	ole.IUnknown
 }
 
 func NewBluetoothLEManufacturerData() (*BluetoothLEManufacturerData, error) {
@@ -25,6 +25,34 @@ func NewBluetoothLEManufacturerData() (*BluetoothLEManufacturerData, error) {
 		return nil, err
 	}
 	return (*BluetoothLEManufacturerData)(unsafe.Pointer(inspectable)), nil
+}
+
+func (impl *BluetoothLEManufacturerData) GetCompanyId() (uint16, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEManufacturerData))
+	defer itf.Release()
+	v := (*iBluetoothLEManufacturerData)(unsafe.Pointer(itf))
+	return v.GetCompanyId()
+}
+
+func (impl *BluetoothLEManufacturerData) SetCompanyId(value uint16) error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEManufacturerData))
+	defer itf.Release()
+	v := (*iBluetoothLEManufacturerData)(unsafe.Pointer(itf))
+	return v.SetCompanyId(value)
+}
+
+func (impl *BluetoothLEManufacturerData) GetData() (*streams.IBuffer, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEManufacturerData))
+	defer itf.Release()
+	v := (*iBluetoothLEManufacturerData)(unsafe.Pointer(itf))
+	return v.GetData()
+}
+
+func (impl *BluetoothLEManufacturerData) SetData(value *streams.IBuffer) error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEManufacturerData))
+	defer itf.Release()
+	v := (*iBluetoothLEManufacturerData)(unsafe.Pointer(itf))
+	return v.SetData(value)
 }
 
 const GUIDiBluetoothLEManufacturerData string = "912dba18-6963-4533-b061-4694dafb34e5"

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -15,7 +15,28 @@ import (
 const SignatureBuffer string = "rc(Windows.Storage.Streams.Buffer;{905a0fe0-bc53-11df-8c49-001e4fc686da})"
 
 type Buffer struct {
-	IBuffer
+	ole.IUnknown
+}
+
+func (impl *Buffer) GetCapacity() (uint32, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDIBuffer))
+	defer itf.Release()
+	v := (*IBuffer)(unsafe.Pointer(itf))
+	return v.GetCapacity()
+}
+
+func (impl *Buffer) GetLength() (uint32, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDIBuffer))
+	defer itf.Release()
+	v := (*IBuffer)(unsafe.Pointer(itf))
+	return v.GetLength()
+}
+
+func (impl *Buffer) SetLength(value uint32) error {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDIBuffer))
+	defer itf.Release()
+	v := (*IBuffer)(unsafe.Pointer(itf))
+	return v.SetLength(value)
 }
 
 const GUIDiBufferFactory string = "71af914d-c10f-484b-bc50-14bc623b3a27"

--- a/windows/storage/streams/datareader.go
+++ b/windows/storage/streams/datareader.go
@@ -10,15 +10,19 @@ import (
 	"unsafe"
 
 	"github.com/go-ole/go-ole"
-	"github.com/saltosystems/winrt-go/windows/foundation"
 )
 
 const SignatureDataReader string = "rc(Windows.Storage.Streams.DataReader;{e2b50029-b4c1-4314-a4b8-fb813a2f275e})"
 
 type DataReader struct {
-	IDataReader
+	ole.IUnknown
+}
 
-	foundation.IClosable
+func (impl *DataReader) ReadBytes(valueSize uint32) ([]uint8, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDIDataReader))
+	defer itf.Release()
+	v := (*IDataReader)(unsafe.Pointer(itf))
+	return v.ReadBytes(valueSize)
 }
 
 const GUIDiDataReaderStatics string = "11fcbfc8-f93a-471b-b121-f379e349313c"

--- a/winrt.go
+++ b/winrt.go
@@ -20,7 +20,7 @@ package winrt
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Storage.Streams.IBuffer
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Storage.Streams.Buffer -method-filter !CreateCopyFromMemoryBuffer -method-filter !CreateMemoryBufferOverIBuffer
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Storage.Streams.IDataReader -method-filter ReadBytes -method-filter !*
-//go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Storage.Streams.DataReader -method-filter !CreateDataReader
+//go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Storage.Streams.DataReader -method-filter FromBuffer -method-filter ReadBytes -method-filter !*
 
 // vector
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Foundation.Collections.IVector`1 -method-filter !GetView


### PR DESCRIPTION
The `QueryInterface` function can be used to retrieve an interface
implemented by a class. This way instead of embedding implemented
interfaces we can just add their methods to the runtime classes and use
`QueryInterface` to call the method from the interface.