### PR TITLE
codegen/delegate: add implementation for AddRef and Release methods

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -6,23 +6,8 @@
 // mangling, the signature doesn't really matter.
 void winrt_{{.Name}}_Invoke(void);
 void winrt_{{.Name}}_QueryInterface(void);
-
-// This is the contract the functions below should adhere to:
-// https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown
-
-static uint64_t winrt_{{.Name}}_AddRef(void) {
-	// This is safe, see winrt_{{.Name}}_Release.
-	return 2;
-}
-
-static uint64_t winrt_{{.Name}}_Release(void) {
-	// Pretend there is one reference left.
-	// The docs say:
-	// > This value is intended to be used only for test purposes.
-	// Also see:
-	// https://docs.microsoft.com/en-us/archive/msdn-magazine/2013/august/windows-with-c-the-windows-runtime-application-model
-	return 1;
-}
+uint64_t winrt_{{.Name}}_AddRef(void);
+uint64_t winrt_{{.Name}}_Release(void);
 
 // The Vtable structure for WinRT {{.Name}} interfaces.
 typedef struct {
@@ -53,6 +38,7 @@ const Signature{{.Name}} string = "{{.Signature}}"
 type {{.Name}} struct {
 	ole.IUnknown
 	IID      *ole.GUID
+	RefCount *winrt.RefCount
 	Callback {{.Name}}Callback
 }
 
@@ -64,7 +50,9 @@ func New{{.Name}}(iid *ole.GUID, callback TypedEventHandlerCallback) *{{.Name}} 
     inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))
     inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_get{{.Name}}Vtbl()))
     inst.IID = iid
+    inst.RefCount = winrt.NewRefCount()
     inst.Callback = callback
 
+	inst.RefCount.AddRef()
     return inst
 }

--- a/internal/codegen/templates/delegate_exports.tmpl
+++ b/internal/codegen/templates/delegate_exports.tmpl
@@ -1,26 +1,38 @@
 /*
-#include <stddef.h>
+#include <stdlib.h>
 */
 import "C"
 
 //export winrt_{{.Name}}_QueryInterface
 func winrt_{{.Name}}_QueryInterface(instancePtr, iidPtr unsafe.Pointer, ppvObject *unsafe.Pointer) uintptr {
+	// Checkout these sources for more information about the QueryInterface method.
+	//   - https://docs.microsoft.com/en-us/cpp/atl/queryinterface
+	//   - https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)
+
+	if ppvObject == nil {
+		// If ppvObject (the address) is nullptr, then this method returns E_POINTER.
+		return ole.E_POINTER
+	}
+
 	// This function must adhere to the QueryInterface defined here:
 	// https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown
 	iid := (*ole.GUID)(iidPtr)
 	instance := (*{{.Name}})(instancePtr)
-	if ole.IsEqualGUID(iid, instance.IID) {
-		// This is us.
-		*ppvObject = instancePtr
-		return ole.S_OK
+	if ole.IsEqualGUID(iid, instance.IID) || ole.IsEqualGUID(iid, ole.IID_IUnknown) || ole.IsEqualGUID(iid, ole.IID_IInspectable){
+		*ppvObject = unsafe.Pointer(instance)
+	} else {
+		*ppvObject = nil
+		// Return E_NOINTERFACE if the interface is not supported
+		return ole.E_NOINTERFACE
 	}
-	if ole.IsEqualGUID(iid, ole.IID_IUnknown) {
-		// This is our parent. There are some limitations as to what we can
-		// return here, but returning the *{{.Name}} pointer is fine.
-		*ppvObject = instancePtr
-		return ole.S_OK
-	}
-	return 0x80004002 // E_NOTINTERFACE
+
+
+	// If the COM object implements the interface, then it returns
+	// a pointer to that interface after calling IUnknown::AddRef on it.
+	(*ole.IUnknown)(*ppvObject).AddRef()
+
+	// Return S_OK if the interface is supported
+	return ole.S_OK
 }
 
 //export winrt_{{.Name}}_Invoke
@@ -29,4 +41,22 @@ func winrt_{{.Name}}_Invoke(instancePtr {{range .InParams}},{{.GoVarName}}Ptr{{e
 	instance := (*{{.Name}})(instancePtr)
 	instance.Callback(instance, {{range .InParams}}{{.GoVarName}}Ptr,{{end}})
 	return ole.S_OK
+}
+
+//export winrt_{{.Name}}_AddRef
+func winrt_{{.Name}}_AddRef(instancePtr unsafe.Pointer) uint64 {
+	instance := (*{{.Name}})(instancePtr)
+	return instance.RefCount.AddRef()
+}
+
+//export winrt_{{.Name}}_Release
+func winrt_{{.Name}}_Release(instancePtr unsafe.Pointer) uint64 {
+	instance := (*{{.Name}})(instancePtr)
+	rem := instance.RefCount.Release()
+	if rem == 0 {
+		// We're done.
+		instance.Callback = nil
+		C.free(instancePtr)
+	}
+	return rem
 }

--- a/internal/codegen/templates/file.tmpl
+++ b/internal/codegen/templates/file.tmpl
@@ -9,6 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 	"github.com/go-ole/go-ole"
+	"github.com/saltosystems/winrt-go"
 	{{range .Imports}}"{{.}}"
 	{{end}}
 )

--- a/refcount.go
+++ b/refcount.go
@@ -1,0 +1,34 @@
+package winrt
+
+import "sync"
+
+// RefCount represents a reference counter.
+type RefCount struct {
+	sync.Mutex
+	refs uint64
+}
+
+// NewRefCount creates a new reference counter instance with the counter set to zero.
+func NewRefCount() *RefCount {
+	return &RefCount{}
+}
+
+// AddRef increments the reference counter by one
+func (r *RefCount) AddRef() uint64 {
+	r.Lock()
+	defer r.Unlock()
+	r.refs++
+	return r.refs
+}
+
+// Release decrements the reference counter by one. If it was already zero, it will just return zero.
+func (r *RefCount) Release() uint64 {
+	r.Lock()
+	defer r.Unlock()
+
+	if r.refs > 0 {
+		r.refs--
+	}
+
+	return r.refs
+}

--- a/windows/foundation/typedeventhandler_exports.go
+++ b/windows/foundation/typedeventhandler_exports.go
@@ -12,28 +12,39 @@ import (
 )
 
 /*
-#include <stddef.h>
+#include <stdlib.h>
 */
 import "C"
 
 //export winrt_TypedEventHandler_QueryInterface
 func winrt_TypedEventHandler_QueryInterface(instancePtr, iidPtr unsafe.Pointer, ppvObject *unsafe.Pointer) uintptr {
+	// Checkout these sources for more information about the QueryInterface method.
+	//   - https://docs.microsoft.com/en-us/cpp/atl/queryinterface
+	//   - https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nf-unknwn-iunknown-queryinterface(refiid_void)
+
+	if ppvObject == nil {
+		// If ppvObject (the address) is nullptr, then this method returns E_POINTER.
+		return ole.E_POINTER
+	}
+
 	// This function must adhere to the QueryInterface defined here:
 	// https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown
 	iid := (*ole.GUID)(iidPtr)
 	instance := (*TypedEventHandler)(instancePtr)
-	if ole.IsEqualGUID(iid, instance.IID) {
-		// This is us.
-		*ppvObject = instancePtr
-		return ole.S_OK
+	if ole.IsEqualGUID(iid, instance.IID) || ole.IsEqualGUID(iid, ole.IID_IUnknown) || ole.IsEqualGUID(iid, ole.IID_IInspectable) {
+		*ppvObject = unsafe.Pointer(instance)
+	} else {
+		*ppvObject = nil
+		// Return E_NOINTERFACE if the interface is not supported
+		return ole.E_NOINTERFACE
 	}
-	if ole.IsEqualGUID(iid, ole.IID_IUnknown) {
-		// This is our parent. There are some limitations as to what we can
-		// return here, but returning the *TypedEventHandler pointer is fine.
-		*ppvObject = instancePtr
-		return ole.S_OK
-	}
-	return 0x80004002 // E_NOTINTERFACE
+
+	// If the COM object implements the interface, then it returns
+	// a pointer to that interface after calling IUnknown::AddRef on it.
+	(*ole.IUnknown)(*ppvObject).AddRef()
+
+	// Return S_OK if the interface is supported
+	return ole.S_OK
 }
 
 //export winrt_TypedEventHandler_Invoke
@@ -42,4 +53,22 @@ func winrt_TypedEventHandler_Invoke(instancePtr, senderPtr, argsPtr unsafe.Point
 	instance := (*TypedEventHandler)(instancePtr)
 	instance.Callback(instance, senderPtr, argsPtr)
 	return ole.S_OK
+}
+
+//export winrt_TypedEventHandler_AddRef
+func winrt_TypedEventHandler_AddRef(instancePtr unsafe.Pointer) uint64 {
+	instance := (*TypedEventHandler)(instancePtr)
+	return instance.RefCount.AddRef()
+}
+
+//export winrt_TypedEventHandler_Release
+func winrt_TypedEventHandler_Release(instancePtr unsafe.Pointer) uint64 {
+	instance := (*TypedEventHandler)(instancePtr)
+	rem := instance.RefCount.Release()
+	if rem == 0 {
+		// We're done.
+		instance.Callback = nil
+		C.free(instancePtr)
+	}
+	return rem
 }


### PR DESCRIPTION
These two methods were previously always returning a constant value. So
delegates were never freed from memory. Now each delegate will hold a
reference counter, and when it reaches zero the underlying struct will
be freed from memory.