### PR TITLE
codegen/delegates: add support for primitive types in delegate callbacks

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -931,13 +931,34 @@ func (g *generator) elementType(ctx *types.Context, e types.Element) (*genParamT
 		if err != nil {
 			return nil, err
 		}
+
+		elementTypeDef, err := g.mdStore.TypeDefByName(namespace + "." + name)
+		if err != nil {
+			return nil, err
+		}
+
+		// if its an enum, we will need the underlying type
+		isEnum := false
+		enumType := ""
+		if elementTypeDef.IsEnum() {
+			enumData, err := g.createGenEnum(elementTypeDef)
+			if err != nil {
+				return nil, err
+			}
+
+			// Treat the enum as a primitive
+			isEnum = true
+			enumType = enumData.Type
+		}
 		return &genParamType{
-			namespace:    namespace,
-			name:         name,
-			IsPointer:    false,
-			IsPrimitive:  false,
-			IsArray:      false,
-			defaultValue: g.elementDefaultValue(ctx, e),
+			namespace:          namespace,
+			name:               name,
+			IsPointer:          false,
+			IsPrimitive:        false,
+			IsArray:            false,
+			IsEnum:             isEnum,
+			UnderlyingEnumType: enumType,
+			defaultValue:       g.elementDefaultValue(ctx, e),
 		}, nil
 	case types.ELEMENT_TYPE_VAR:
 		// A class variable type modifier

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -146,9 +146,11 @@ type genParamType struct {
 	namespace string
 	name      string
 
-	IsPointer   bool
-	IsArray     bool
-	IsPrimitive bool
+	IsPointer          bool
+	IsArray            bool
+	IsPrimitive        bool
+	IsEnum             bool
+	UnderlyingEnumType string
 
 	defaultValue genDefaultValue
 }

--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -46,7 +46,7 @@ type {{.Name}}Callback func(instance *{{.Name}},{{- range .InParams -}}
 	{{.GoVarName}} {{template "variabletype.tmpl" . }},
 {{- end -}})
 
-func New{{.Name}}(iid *ole.GUID, callback TypedEventHandlerCallback) *{{.Name}} {
+func New{{.Name}}(iid *ole.GUID, callback {{.Name}}Callback) *{{.Name}} {
     inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))
     inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_get{{.Name}}Vtbl()))
     inst.IID = iid

--- a/internal/codegen/templates/delegate_exports.tmpl
+++ b/internal/codegen/templates/delegate_exports.tmpl
@@ -36,10 +36,24 @@ func winrt_{{.Name}}_QueryInterface(instancePtr, iidPtr unsafe.Pointer, ppvObjec
 }
 
 //export winrt_{{.Name}}_Invoke
-func winrt_{{.Name}}_Invoke(instancePtr {{range .InParams}},{{.GoVarName}}Ptr{{end}} unsafe.Pointer) uintptr {
+func winrt_{{.Name}}_Invoke(instancePtr unsafe.Pointer {{range .InParams -}}
+		,
+		{{- if .Type.IsEnum -}}
+			{{.GoVarName}}Raw {{.Type.UnderlyingEnumType}}
+		{{- else -}}
+			{{.GoVarName}}Ptr unsafe.Pointer
+		{{- end}}
+	{{- end -}}) uintptr {
 	// See the quote above.
 	instance := (*{{.Name}})(instancePtr)
-	instance.Callback(instance, {{range .InParams}}{{.GoVarName}}Ptr,{{end}})
+	{{range .InParams -}}
+		{{if .Type.IsEnum -}}
+			{{.GoVarName}} := ({{template "variabletype.tmpl" . }})({{.GoVarName}}Raw)
+		{{else -}}
+			{{.GoVarName}} := ({{template "variabletype.tmpl" . }})({{.GoVarName}}Ptr)
+		{{end -}}
+	{{end -}}
+	instance.Callback(instance, {{range .InParams}}{{.GoVarName}},{{end}})
 	return ole.S_OK
 }
 

--- a/windows/foundation/typedeventhandler_exports.go
+++ b/windows/foundation/typedeventhandler_exports.go
@@ -48,10 +48,12 @@ func winrt_TypedEventHandler_QueryInterface(instancePtr, iidPtr unsafe.Pointer, 
 }
 
 //export winrt_TypedEventHandler_Invoke
-func winrt_TypedEventHandler_Invoke(instancePtr, senderPtr, argsPtr unsafe.Pointer) uintptr {
+func winrt_TypedEventHandler_Invoke(instancePtr unsafe.Pointer, senderPtr unsafe.Pointer, argsPtr unsafe.Pointer) uintptr {
 	// See the quote above.
 	instance := (*TypedEventHandler)(instancePtr)
-	instance.Callback(instance, senderPtr, argsPtr)
+	sender := (unsafe.Pointer)(senderPtr)
+	args := (unsafe.Pointer)(argsPtr)
+	instance.Callback(instance, sender, args)
 	return ole.S_OK
 }
 


### PR DESCRIPTION
Go functions exported to C may contain enums, which are just primitive
values. When these enums are used in the signature of an exported
function, they have to be defined using the underlying primitive type.