### PR TITLE
codegen: always use the overload method name to avoid conflicts in go

### DIFF
--- a/internal/winmd/methoddef.go
+++ b/internal/winmd/methoddef.go
@@ -1,0 +1,76 @@
+package winmd
+
+import (
+	"github.com/tdakkota/win32metadata/md"
+	"github.com/tdakkota/win32metadata/types"
+)
+
+// GetMethodOverloadName finds and returns the overload attribute for the given method
+func GetMethodOverloadName(ctx *types.Context, methodDef *types.MethodDef) string {
+	cAttrTable := ctx.Table(md.CustomAttribute)
+	for i := uint32(0); i < cAttrTable.RowCount(); i++ {
+		var cAttr types.CustomAttribute
+		if err := cAttr.FromRow(cAttrTable.Row(i)); err != nil {
+			continue
+		}
+
+		// - Parent: The owner of the Attribute must be the given func
+		if cAttrParentTable, _ := cAttr.Parent.Table(); cAttrParentTable != md.MethodDef {
+			continue
+		}
+
+		var parentMethodDef types.MethodDef
+		row, ok := cAttr.Parent.Row(ctx)
+		if !ok {
+			continue
+		}
+		if err := parentMethodDef.FromRow(row); err != nil {
+			continue
+		}
+
+		// does the blob belong to the method we're looking for?
+		if parentMethodDef.Name != methodDef.Name || string(parentMethodDef.Signature) != string(methodDef.Signature) {
+			continue
+		}
+
+		// - Type: the attribute type must be the given type
+		// the cAttr.Type table can be either a MemberRef or a MethodRef.
+		// Since we are looking for a type, we will only consider the MemberRef.
+		if cAttrTypeTable, _ := cAttr.Type.Table(); cAttrTypeTable != md.MemberRef {
+			continue
+		}
+
+		var attrTypeMemberRef types.MemberRef
+		row, ok = cAttr.Type.Row(ctx)
+		if !ok {
+			continue
+		}
+		if err := attrTypeMemberRef.FromRow(row); err != nil {
+			continue
+		}
+
+		// we need to check the MemberRef Class
+		// the value can belong to several tables, but we are only going to check for TypeRef
+		if classTable, _ := attrTypeMemberRef.Class.Table(); classTable != md.TypeRef {
+			continue
+		}
+
+		var attrTypeRef types.TypeRef
+		row, ok = attrTypeMemberRef.Class.Row(ctx)
+		if !ok {
+			continue
+		}
+		if err := attrTypeRef.FromRow(row); err != nil {
+			continue
+		}
+
+		if attrTypeRef.TypeNamespace+"."+attrTypeRef.TypeName == AttributeTypeOverloadAttribute {
+			// Metadata values start with 0x01 0x00 and ends with 0x00 0x00
+			mdVal := cAttr.Value[2 : len(cAttr.Value)-2]
+			// the next value is the length of the string
+			mdVal = mdVal[1:]
+			return string(mdVal)
+		}
+	}
+	return methodDef.Name
+}

--- a/internal/winmd/typedef.go
+++ b/internal/winmd/typedef.go
@@ -10,25 +10,6 @@ import (
 	"github.com/tdakkota/win32metadata/types"
 )
 
-// Custom Attributes
-const (
-	AttributeTypeGUID                 = "Windows.Foundation.Metadata.GuidAttribute"
-	AttributeTypeExclusiveTo          = "Windows.Foundation.Metadata.ExclusiveToAttribute"
-	AttributeTypeStaticAttribute      = "Windows.Foundation.Metadata.StaticAttribute"
-	AttributeTypeActivatableAttribute = "Windows.Foundation.Metadata.ActivatableAttribute"
-	AttributeTypeDefaultAttribute     = "Windows.Foundation.Metadata.DefaultAttribute"
-)
-
-// HasContext is a helper struct that holds the original context of a metadata element.
-type HasContext struct {
-	originalCtx *types.Context
-}
-
-// Ctx return the original context of the element.
-func (hctx *HasContext) Ctx() *types.Context {
-	return hctx.originalCtx
-}
-
 // TypeDef is a helper struct that wraps types.TypeDef and stores the original context
 // of the typeDef.
 type TypeDef struct {
@@ -75,8 +56,8 @@ func (typeDef *TypeDef) GetValueForEnumField(fieldIndex uint32) (string, error) 
 	return "", fmt.Errorf("no value found for field %d", fieldIndex)
 }
 
-// GetTypeDefAttributeWithType returns the value of the given attribute type and fails if not found.
-func (typeDef *TypeDef) GetTypeDefAttributeWithType(lookupAttrTypeClass string) ([]byte, error) {
+// GetAttributeWithType returns the value of the given attribute type and fails if not found.
+func (typeDef *TypeDef) GetAttributeWithType(lookupAttrTypeClass string) ([]byte, error) {
 	result := typeDef.GetTypeDefAttributesWithType(lookupAttrTypeClass)
 	if len(result) == 0 {
 		return nil, fmt.Errorf("type %s has no custom attribute %s", typeDef.TypeNamespace+"."+typeDef.TypeName, lookupAttrTypeClass)
@@ -291,7 +272,7 @@ func (typeDef *TypeDef) IsRuntimeClass() bool {
 
 // GUID returns the GUID of the type.
 func (typeDef *TypeDef) GUID() (string, error) {
-	blob, err := typeDef.GetTypeDefAttributeWithType(AttributeTypeGUID)
+	blob, err := typeDef.GetAttributeWithType(AttributeTypeGUID)
 	if err != nil {
 		return "", err
 	}

--- a/internal/winmd/winmd.go
+++ b/internal/winmd/winmd.go
@@ -6,7 +6,29 @@ import (
 	"embed"
 	"io/fs"
 	"io/ioutil"
+
+	"github.com/tdakkota/win32metadata/types"
 )
+
+// Custom Attributes
+const (
+	AttributeTypeGUID                 = "Windows.Foundation.Metadata.GuidAttribute"
+	AttributeTypeExclusiveTo          = "Windows.Foundation.Metadata.ExclusiveToAttribute"
+	AttributeTypeStaticAttribute      = "Windows.Foundation.Metadata.StaticAttribute"
+	AttributeTypeActivatableAttribute = "Windows.Foundation.Metadata.ActivatableAttribute"
+	AttributeTypeDefaultAttribute     = "Windows.Foundation.Metadata.DefaultAttribute"
+	AttributeTypeOverloadAttribute    = "Windows.Foundation.Metadata.OverloadAttribute"
+)
+
+// HasContext is a helper struct that holds the original context of a metadata element.
+type HasContext struct {
+	originalCtx *types.Context
+}
+
+// Ctx return the original context of the element.
+func (hctx *HasContext) Ctx() *types.Context {
+	return hctx.originalCtx
+}
 
 //go:embed metadata/*.winmd
 var files embed.FS


### PR DESCRIPTION
Each method in the winmd metadata file may contain an OverloadAttribute
with an alternative name for the method to avoid any conflicts.