### PR TITLE
codegen: add boolean parameter support

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -751,7 +751,7 @@ func (g *generator) getReturnParameters(curPackage string, typeDef *winmd.TypeDe
 		// return param always has an index of zero
 		callerPackage: curPackage,
 		varName:       "out",
-		IsOut:         false, // notrelevant
+		IsOut:         true,
 		Type:          elType,
 	})
 

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -217,6 +217,9 @@ func getTemplates() (*template.Template, error) {
 func funcs() template.FuncMap {
 	return template.FuncMap{
 		"funcName": funcName,
+		"concat": func(a, b []*genParam) []*genParam {
+			return append(a, b...)
+		},
 	}
 }
 

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -21,22 +21,27 @@ hr, _, _ := syscall.SyscallN(
     {{else}}
         uintptr(unsafe.Pointer(v)), // this
     {{end -}}
-    {{range .InParams -}}
+    {{range (concat .InParams .ReturnParams) -}}
         {{if .IsOut -}}
-            {{/* Arrays need to pass a pointer to their first element */ -}}
-            uintptr(unsafe.Pointer(&{{.GoVarName}}{{if .Type.IsArray }}[0]{{end}})),   // out {{.GoTypeName}}
+            {{if .Type.IsArray -}}
+                {{/* Arrays need to pass a pointer to their first element */ -}}
+                uintptr(unsafe.Pointer(&{{.GoVarName}}[0])),   // out {{.GoTypeName}}
+            {{else -}}
+                uintptr(unsafe.Pointer(&{{.GoVarName}})),   // out {{.GoTypeName}}
+            {{end -}}
         {{else if .Type.IsPointer -}}
             uintptr(unsafe.Pointer({{.GoVarName}})),   // in {{.GoTypeName}}
         {{else if .Type.IsPrimitive -}}
-            uintptr({{.GoVarName}}),   // in {{.GoVarName}}
+            {{ if eq .GoTypeName "bool" -}}
+                uintptr(*(*byte)(unsafe.Pointer(&{{.GoVarName}}))),   // in {{.GoVarName}}
+            {{else -}}
+                uintptr({{.GoVarName}}),   // in {{.GoVarName}}
+            {{end -}}
         {{else -}}
             uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoVarName}}
         {{end -}}
     {{end -}}
-    {{range .ReturnParams -}}
-        uintptr(unsafe.Pointer(&{{.GoVarName}})), // out {{.GoTypeName}}
-    {{end}})
-
+)
 
 if hr != 0 {
     return {{range .InParams}}{{if .IsOut}}{{.GoDefaultValue}}, {{end}}{{end -}}


### PR DESCRIPTION
Booleans are represented as bytes in WinRT. This works because the bool
is represented as a single byte in Go, so we make a direct translation
from bool to byte.