### PR TITLE
codegen: use the first element of array on input parameters

### DIFF
--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -40,11 +40,11 @@ hr, _, _ := syscall.SyscallN(
         uintptr(unsafe.Pointer(v)), // this
     {{end -}}
     {{range (concat .InParams .ReturnParams) -}}
-        {{if .IsOut -}}
-            {{if .Type.IsArray -}}
-                {{/* Arrays need to pass a pointer to their first element */ -}}
-                uintptr(unsafe.Pointer(&{{.GoVarName}}[0])),   // out {{.GoTypeName}}
-            {{else if .Type.IsPrimitive -}}
+        {{if .Type.IsArray -}}
+            {{/* Arrays need to pass a pointer to their first element */ -}}
+            uintptr(unsafe.Pointer(&{{.GoVarName}}[0])),   // {{if .IsOut}}out{{else}}in{{end}} {{.GoTypeName}}
+        {{else if .IsOut -}}
+            {{if .Type.IsPrimitive -}}
                 {{if eq .GoTypeName "string" -}}
                     uintptr(unsafe.Pointer(&{{.GoVarName}}HStr)),   // out {{.GoTypeName}}
                 {{else -}}
@@ -57,14 +57,14 @@ hr, _, _ := syscall.SyscallN(
             uintptr(unsafe.Pointer({{.GoVarName}})),   // in {{.GoTypeName}}
         {{else if .Type.IsPrimitive -}}
             {{ if eq .GoTypeName "bool" -}}
-                uintptr(*(*byte)(unsafe.Pointer(&{{.GoVarName}}))),   // in {{.GoVarName}}
+                uintptr(*(*byte)(unsafe.Pointer(&{{.GoVarName}}))),   // in {{.GoTypeName}}
             {{ else if eq .GoTypeName "string" -}}
-                uintptr({{.GoVarName}}HStr),   // in {{.GoVarName}}
+                uintptr({{.GoVarName}}HStr),   // in {{.GoTypeName}}
             {{else -}}
-                uintptr({{.GoVarName}}),   // in {{.GoVarName}}
+                uintptr({{.GoVarName}}),   // in {{.GoTypeName}}
             {{end -}}
         {{else -}}
-            uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoVarName}}
+            uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoTypeName}}
         {{end -}}
     {{end -}}
 )

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
@@ -112,7 +112,7 @@ func (v *iBluetoothLEAdvertisement) SetLocalName(value string) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetLocalName,
 		uintptr(unsafe.Pointer(v)), // this
-		uintptr(valueHStr),         // in value
+		uintptr(valueHStr),         // in string
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -170,7 +170,7 @@ func (v *iBluetoothLEAdvertisementWatcher) RemoveReceived(token foundation.Event
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveReceived,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in token
+		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -200,7 +200,7 @@ func (v *iBluetoothLEAdvertisementWatcher) RemoveStopped(token foundation.EventR
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveStopped,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in token
+		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -94,7 +94,7 @@ func (v *iBluetoothLEManufacturerData) SetCompanyId(value uint16) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetCompanyId,
 		uintptr(unsafe.Pointer(v)), // this
-		uintptr(value),             // in value
+		uintptr(value),             // in uint16
 	)
 
 	if hr != 0 {
@@ -161,7 +161,7 @@ func Create(companyId uint16, data *streams.IBuffer) (*BluetoothLEManufacturerDa
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Create,
 		0,                             // this is a static func, so there's no this
-		uintptr(companyId),            // in companyId
+		uintptr(companyId),            // in uint16
 		uintptr(unsafe.Pointer(data)), // in streams.IBuffer
 		uintptr(unsafe.Pointer(&out)), // out BluetoothLEManufacturerData
 	)

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -131,7 +131,7 @@ func (v *iBluetoothLEDevice) RemoveConnectionStatusChanged(token foundation.Even
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveConnectionStatusChanged,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in token
+		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -202,7 +202,7 @@ func (v *iBluetoothLEDevice3) GetGattServicesWithCacheModeAsync(cacheMode Blueto
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetGattServicesWithCacheModeAsync,
 		uintptr(unsafe.Pointer(v)),          // this
-		uintptr(unsafe.Pointer(&cacheMode)), // in cacheMode
+		uintptr(unsafe.Pointer(&cacheMode)), // in BluetoothCacheMode
 		uintptr(unsafe.Pointer(&out)),       // out foundation.IAsyncOperation
 	)
 
@@ -296,8 +296,8 @@ func FromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoothAddress uint64, 
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().FromBluetoothAddressWithBluetoothAddressTypeAsync,
 		0,                         // this is a static func, so there's no this
-		uintptr(bluetoothAddress), // in bluetoothAddress
-		uintptr(unsafe.Pointer(&bluetoothAddressType)), // in bluetoothAddressType
+		uintptr(bluetoothAddress), // in uint64
+		uintptr(unsafe.Pointer(&bluetoothAddressType)), // in BluetoothAddressType
 		uintptr(unsafe.Pointer(&out)),                  // out foundation.IAsyncOperation
 	)
 
@@ -338,7 +338,7 @@ func FromBluetoothAddressAsync(bluetoothAddress uint64) (*foundation.IAsyncOpera
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().FromBluetoothAddressAsync,
 		0,                             // this is a static func, so there's no this
-		uintptr(bluetoothAddress),     // in bluetoothAddress
+		uintptr(bluetoothAddress),     // in uint64
 		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
 	)
 

--- a/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
@@ -153,7 +153,7 @@ func (v *iGattDeviceService3) GetCharacteristicsWithCacheModeAsync(cacheMode blu
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetCharacteristicsWithCacheModeAsync,
 		uintptr(unsafe.Pointer(v)),          // this
-		uintptr(unsafe.Pointer(&cacheMode)), // in cacheMode
+		uintptr(unsafe.Pointer(&cacheMode)), // in bluetooth.BluetoothCacheMode
 		uintptr(unsafe.Pointer(&out)),       // out foundation.IAsyncOperation
 	)
 

--- a/windows/devices/bluetooth/genericattributeprofile/gattsession.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsession.go
@@ -93,7 +93,7 @@ func (v *iGattSession) SetMaintainConnection(value bool) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetMaintainConnection,
 		uintptr(unsafe.Pointer(v)),                // this
-		uintptr(*(*byte)(unsafe.Pointer(&value))), // in value
+		uintptr(*(*byte)(unsafe.Pointer(&value))), // in bool
 	)
 
 	if hr != 0 {

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -45,7 +45,7 @@ func (v *IVector) GetAt(index uint32) (unsafe.Pointer, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetAt,
 		uintptr(unsafe.Pointer(v)),    // this
-		uintptr(index),                // in index
+		uintptr(index),                // in uint32
 		uintptr(unsafe.Pointer(&out)), // out unsafe.Pointer
 	)
 
@@ -92,7 +92,7 @@ func (v *IVector) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
 		uintptr(unsafe.Pointer(&index)), // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)
@@ -108,8 +108,8 @@ func (v *IVector) SetAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetAt,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(index),                  // in index
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(index),                  // in uint32
+		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -123,8 +123,8 @@ func (v *IVector) InsertAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().InsertAt,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(index),                  // in index
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(index),                  // in uint32
+		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -138,7 +138,7 @@ func (v *IVector) RemoveAt(index uint32) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveAt,
 		uintptr(unsafe.Pointer(v)), // this
-		uintptr(index),             // in index
+		uintptr(index),             // in uint32
 	)
 
 	if hr != 0 {
@@ -152,7 +152,7 @@ func (v *IVector) Append(value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Append,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -194,8 +194,8 @@ func (v *IVector) GetMany(startIndex uint32, itemsSize uint32) ([]unsafe.Pointer
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetMany,
 		uintptr(unsafe.Pointer(v)),         // this
-		uintptr(startIndex),                // in startIndex
-		uintptr(itemsSize),                 // in itemsSize
+		uintptr(startIndex),                // in uint32
+		uintptr(itemsSize),                 // in uint32
 		uintptr(unsafe.Pointer(&items[0])), // out unsafe.Pointer
 		uintptr(unsafe.Pointer(&out)),      // out uint32
 	)
@@ -210,9 +210,9 @@ func (v *IVector) GetMany(startIndex uint32, itemsSize uint32) ([]unsafe.Pointer
 func (v *IVector) ReplaceAll(itemsSize uint32, items []unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().ReplaceAll,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(itemsSize),              // in itemsSize
-		uintptr(unsafe.Pointer(&items)), // in items
+		uintptr(unsafe.Pointer(v)),         // this
+		uintptr(itemsSize),                 // in uint32
+		uintptr(unsafe.Pointer(&items[0])), // in unsafe.Pointer
 	)
 
 	if hr != 0 {

--- a/windows/foundation/collections/ivectorview.go
+++ b/windows/foundation/collections/ivectorview.go
@@ -37,7 +37,7 @@ func (v *IVectorView) GetAt(index uint32) (unsafe.Pointer, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetAt,
 		uintptr(unsafe.Pointer(v)),    // this
-		uintptr(index),                // in index
+		uintptr(index),                // in uint32
 		uintptr(unsafe.Pointer(&out)), // out unsafe.Pointer
 	)
 
@@ -69,7 +69,7 @@ func (v *IVectorView) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in value
+		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
 		uintptr(unsafe.Pointer(&index)), // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)
@@ -87,8 +87,8 @@ func (v *IVectorView) GetMany(startIndex uint32, itemsSize uint32) ([]unsafe.Poi
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetMany,
 		uintptr(unsafe.Pointer(v)),         // this
-		uintptr(startIndex),                // in startIndex
-		uintptr(itemsSize),                 // in itemsSize
+		uintptr(startIndex),                // in uint32
+		uintptr(itemsSize),                 // in uint32
 		uintptr(unsafe.Pointer(&items[0])), // out unsafe.Pointer
 		uintptr(unsafe.Pointer(&out)),      // out uint32
 	)

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -67,7 +67,7 @@ func Create(capacity uint32) (*Buffer, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Create,
 		0,                             // this is a static func, so there's no this
-		uintptr(capacity),             // in capacity
+		uintptr(capacity),             // in uint32
 		uintptr(unsafe.Pointer(&out)), // out Buffer
 	)
 

--- a/windows/storage/streams/ibuffer.go
+++ b/windows/storage/streams/ibuffer.go
@@ -65,7 +65,7 @@ func (v *IBuffer) SetLength(value uint32) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetLength,
 		uintptr(unsafe.Pointer(v)), // this
-		uintptr(value),             // in value
+		uintptr(value),             // in uint32
 	)
 
 	if hr != 0 {

--- a/windows/storage/streams/idatareader.go
+++ b/windows/storage/streams/idatareader.go
@@ -59,7 +59,7 @@ func (v *IDataReader) ReadBytes(valueSize uint32) ([]uint8, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().ReadBytes,
 		uintptr(unsafe.Pointer(v)),         // this
-		uintptr(valueSize),                 // in valueSize
+		uintptr(valueSize),                 // in uint32
 		uintptr(unsafe.Pointer(&value[0])), // out uint8
 	)
 


### PR DESCRIPTION
This change also unifies in/out parameter comments to always include the
parameter type instead of its name.