### PR TITLE
codegen: treat enums as primitives when passing them to/from WinRT

### DIFF
--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -44,7 +44,7 @@ hr, _, _ := syscall.SyscallN(
             {{/* Arrays need to pass a pointer to their first element */ -}}
             uintptr(unsafe.Pointer(&{{.GoVarName}}[0])),   // {{if .IsOut}}out{{else}}in{{end}} {{.GoTypeName}}
         {{else if .IsOut -}}
-            {{if .Type.IsPrimitive -}}
+            {{if (or .Type.IsPrimitive .Type.IsEnum) -}}
                 {{if eq .GoTypeName "string" -}}
                     uintptr(unsafe.Pointer(&{{.GoVarName}}HStr)),   // out {{.GoTypeName}}
                 {{else -}}
@@ -55,7 +55,7 @@ hr, _, _ := syscall.SyscallN(
             {{end -}}
         {{else if .Type.IsPointer -}}
             uintptr(unsafe.Pointer({{.GoVarName}})),   // in {{.GoTypeName}}
-        {{else if .Type.IsPrimitive -}}
+        {{else if (or .Type.IsPrimitive .Type.IsEnum) -}}
             {{ if eq .GoTypeName "bool" -}}
                 uintptr(*(*byte)(unsafe.Pointer(&{{.GoVarName}}))),   // in {{.GoTypeName}}
             {{ else if eq .GoTypeName "string" -}}

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -201,9 +201,9 @@ func (v *iBluetoothLEDevice3) GetGattServicesWithCacheModeAsync(cacheMode Blueto
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetGattServicesWithCacheModeAsync,
-		uintptr(unsafe.Pointer(v)),          // this
-		uintptr(unsafe.Pointer(&cacheMode)), // in BluetoothCacheMode
-		uintptr(unsafe.Pointer(&out)),       // out foundation.IAsyncOperation
+		uintptr(unsafe.Pointer(v)),    // this
+		uintptr(cacheMode),            // in BluetoothCacheMode
+		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
 	)
 
 	if hr != 0 {
@@ -295,10 +295,10 @@ func FromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoothAddress uint64, 
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().FromBluetoothAddressWithBluetoothAddressTypeAsync,
-		0,                         // this is a static func, so there's no this
-		uintptr(bluetoothAddress), // in uint64
-		uintptr(unsafe.Pointer(&bluetoothAddressType)), // in BluetoothAddressType
-		uintptr(unsafe.Pointer(&out)),                  // out foundation.IAsyncOperation
+		0,                             // this is a static func, so there's no this
+		uintptr(bluetoothAddress),     // in uint64
+		uintptr(bluetoothAddressType), // in BluetoothAddressType
+		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
@@ -152,9 +152,9 @@ func (v *iGattDeviceService3) GetCharacteristicsWithCacheModeAsync(cacheMode blu
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GetCharacteristicsWithCacheModeAsync,
-		uintptr(unsafe.Pointer(v)),          // this
-		uintptr(unsafe.Pointer(&cacheMode)), // in bluetooth.BluetoothCacheMode
-		uintptr(unsafe.Pointer(&out)),       // out foundation.IAsyncOperation
+		uintptr(unsafe.Pointer(v)),    // this
+		uintptr(cacheMode),            // in bluetooth.BluetoothCacheMode
+		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
 	)
 
 	if hr != 0 {


### PR DESCRIPTION
WinRT enums are just numeric values, so we should pass and retrieve them to/from WinRT in the same way.