### PR TITLE
codegen: fix nolint directive

### DIFF
--- a/internal/codegen/templates/file.tmpl
+++ b/internal/codegen/templates/file.tmpl
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package {{.Package}}
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisement.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementdatasection.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementreceivedeventargs.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstatus.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstatus.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 type BluetoothLEAdvertisementWatcherStatus int32

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcherstoppedeventargs.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package advertisement
 
 import (

--- a/windows/devices/bluetooth/bluetoothaddresstype.go
+++ b/windows/devices/bluetooth/bluetoothaddresstype.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package bluetooth
 
 type BluetoothAddressType int32

--- a/windows/devices/bluetooth/bluetoothcachemode.go
+++ b/windows/devices/bluetooth/bluetoothcachemode.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package bluetooth
 
 type BluetoothCacheMode int32

--- a/windows/devices/bluetooth/bluetoothconnectionstatus.go
+++ b/windows/devices/bluetooth/bluetoothconnectionstatus.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package bluetooth
 
 type BluetoothConnectionStatus int32

--- a/windows/devices/bluetooth/bluetoothdeviceid.go
+++ b/windows/devices/bluetooth/bluetoothdeviceid.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package bluetooth
 
 import (

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package bluetooth
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattcharacteristic.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattcharacteristic.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattcharacteristicproperties.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattcharacteristicproperties.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 type GattCharacteristicProperties uint32

--- a/windows/devices/bluetooth/genericattributeprofile/gattcharacteristicsresult.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattcharacteristicsresult.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattclientcharacteristicconfigurationdescriptorvalue.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattclientcharacteristicconfigurationdescriptorvalue.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 type GattClientCharacteristicConfigurationDescriptorValue int32

--- a/windows/devices/bluetooth/genericattributeprofile/gattcommunicationstatus.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattcommunicationstatus.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 type GattCommunicationStatus int32

--- a/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattdeviceservice.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattdeviceservicesresult.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattdeviceservicesresult.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattreadresult.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattreadresult.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattsession.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsession.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattvaluechangedeventargs.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattvaluechangedeventargs.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 import (

--- a/windows/devices/bluetooth/genericattributeprofile/gattwriteoption.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattwriteoption.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package genericattributeprofile
 
 type GattWriteOption int32

--- a/windows/foundation/asyncoperationcompletedhandler.go
+++ b/windows/foundation/asyncoperationcompletedhandler.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/foundation/asyncoperationcompletedhandler_exports.go
+++ b/windows/foundation/asyncoperationcompletedhandler_exports.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/foundation/asyncstatus.go
+++ b/windows/foundation/asyncstatus.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 type AsyncStatus int32

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package collections
 
 import (

--- a/windows/foundation/collections/ivectorview.go
+++ b/windows/foundation/collections/ivectorview.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package collections
 
 import (

--- a/windows/foundation/datetime.go
+++ b/windows/foundation/datetime.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 const SignatureDateTime string = "struct(Windows.Foundation.DateTime;i8)"

--- a/windows/foundation/eventregistrationtoken.go
+++ b/windows/foundation/eventregistrationtoken.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 const SignatureEventRegistrationToken string = "struct(Windows.Foundation.EventRegistrationToken;i8)"

--- a/windows/foundation/iasyncoperation.go
+++ b/windows/foundation/iasyncoperation.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/foundation/iclosable.go
+++ b/windows/foundation/iclosable.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/foundation/typedeventhandler_exports.go
+++ b/windows/foundation/typedeventhandler_exports.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package foundation
 
 import (

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (

--- a/windows/storage/streams/datareader.go
+++ b/windows/storage/streams/datareader.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (

--- a/windows/storage/streams/datawriter.go
+++ b/windows/storage/streams/datawriter.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (

--- a/windows/storage/streams/ibuffer.go
+++ b/windows/storage/streams/ibuffer.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (

--- a/windows/storage/streams/idatareader.go
+++ b/windows/storage/streams/idatareader.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (

--- a/windows/storage/streams/idatawriter.go
+++ b/windows/storage/streams/idatawriter.go
@@ -2,7 +2,7 @@
 
 //go:build windows
 
-//nolint
+//nolint:all
 package streams
 
 import (


### PR DESCRIPTION
The previous `nolint` directive was not correct because it was missing the linters we want to disable. This change fixes it by replacing it for `//nolint:all`.