### PR TITLE
codegen: fix typo on BluetoothLEAdvertisementPublisher method filter

### DIFF
--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementpublisher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementpublisher.go
@@ -33,6 +33,13 @@ func (impl *BluetoothLEAdvertisementPublisher) GetStatus() (BluetoothLEAdvertise
 	return v.GetStatus()
 }
 
+func (impl *BluetoothLEAdvertisementPublisher) GetAdvertisement() (*BluetoothLEAdvertisement, error) {
+	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementPublisher))
+	defer itf.Release()
+	v := (*iBluetoothLEAdvertisementPublisher)(unsafe.Pointer(itf))
+	return v.GetAdvertisement()
+}
+
 func (impl *BluetoothLEAdvertisementPublisher) Start() error {
 	itf := impl.MustQueryInterface(ole.NewGUID(GUIDiBluetoothLEAdvertisementPublisher))
 	defer itf.Release()
@@ -79,6 +86,21 @@ func (v *iBluetoothLEAdvertisementPublisher) GetStatus() (BluetoothLEAdvertiseme
 
 	if hr != 0 {
 		return BluetoothLEAdvertisementPublisherStatusCreated, ole.NewError(hr)
+	}
+
+	return out, nil
+}
+
+func (v *iBluetoothLEAdvertisementPublisher) GetAdvertisement() (*BluetoothLEAdvertisement, error) {
+	var out *BluetoothLEAdvertisement
+	hr, _, _ := syscall.SyscallN(
+		v.VTable().GetAdvertisement,
+		uintptr(unsafe.Pointer(v)),    // this
+		uintptr(unsafe.Pointer(&out)), // out BluetoothLEAdvertisement
+	)
+
+	if hr != 0 {
+		return nil, ole.NewError(hr)
 	}
 
 	return out, nil

--- a/winrt.go
+++ b/winrt.go
@@ -15,7 +15,7 @@ package winrt
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisement -method-filter get_LocalName -method-filter put_LocalName -method-filter get_ServiceUuids -method-filter get_ManufacturerData -method-filter get_DataSections -method-filter !*
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementDataSection -method-filter get_DataType -method-filter !*
-//go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher -method-filter set_Advertisement -method-filter Start -method-filter Stop -method-filter get_Status -method-filter !*
+//go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisher -method-filter get_Advertisement -method-filter Start -method-filter Stop -method-filter get_Status -method-filter !*
 //go:generate go run github.com/saltosystems/winrt-go/cmd/winrt-go-gen -debug -class Windows.Devices.Bluetooth.Advertisement.BluetoothLEAdvertisementPublisherStatus
 
 // bluetooth


### PR DESCRIPTION
The `set_Advertisement` filter did not conform to any method. The Advertisement property is read only so this should be `get_Advertisement`.

@glerchundi we never used this property, so another option is to just remove it from the code generation.