### PR TITLE
codegen: add mutex to avoid concurrent access to global callbacks map

### DIFF
--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -220,6 +220,9 @@ func funcs() template.FuncMap {
 		"concat": func(a, b []*genParam) []*genParam {
 			return append(a, b...)
 		},
+		"toLower": func(s string) string {
+			return strings.ToLower(s[:1]) + s[1:]
+		},
 	}
 }
 

--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -46,14 +46,17 @@ type {{.Name}}Callback func(instance *{{.Name}},{{- range .InParams -}}
 	{{.GoVarName}} {{template "variabletype.tmpl" . }},
 {{- end -}})
 
-var callbacks{{.Name}} map[unsafe.Pointer]{{.Name}}Callback = make(map[unsafe.Pointer]{{.Name}}Callback)
+var callbacks{{.Name}} = &{{.Name | toLower}}CallbacksMap {
+	mu:        &sync.Mutex{},
+	callbacks: make(map[unsafe.Pointer]{{.Name}}Callback),
+}
 
 func New{{.Name}}(iid *ole.GUID, callback {{.Name}}Callback) *{{.Name}} {
 	inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))
 	inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_get{{.Name}}Vtbl()))
 	inst.IID = *iid // copy contents
 
-	callbacks{{.Name}}[unsafe.Pointer(inst)] = callback
+	callbacks{{.Name}}.add(unsafe.Pointer(inst), callback)
 
 	inst.addRef()
 	return inst
@@ -77,4 +80,31 @@ func (r *{{.Name}}) removeRef() uint64 {
 	}
 
 	return r.refs
+}
+
+type {{.Name | toLower}}CallbacksMap struct {
+	mu        *sync.Mutex
+	callbacks map[unsafe.Pointer]{{.Name}}Callback
+}
+
+func (m *{{.Name | toLower}}CallbacksMap) add(p unsafe.Pointer, v {{.Name}}Callback) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.callbacks[p] = v
+}
+
+func (m *{{.Name | toLower}}CallbacksMap) get(p unsafe.Pointer) ({{.Name}}Callback, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	v, ok := m.callbacks[p]
+	return v, ok
+}
+
+func (m *{{.Name | toLower}}CallbacksMap) delete(p unsafe.Pointer) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.callbacks, p)
 }

--- a/internal/codegen/templates/delegate_exports.tmpl
+++ b/internal/codegen/templates/delegate_exports.tmpl
@@ -53,7 +53,7 @@ func winrt_{{.Name}}_Invoke(instancePtr unsafe.Pointer {{range .InParams -}}
 			{{.GoVarName}} := ({{template "variabletype.tmpl" . }})({{.GoVarName}}Ptr)
 		{{end -}}
 	{{end -}}
-	if callback, ok := callbacks{{.Name}}[instancePtr]; ok {
+	if callback, ok := callbacks{{.Name}}.get(instancePtr); ok {
 		callback(instance, {{range .InParams}}{{.GoVarName}},{{end}})
 	}
 	return ole.S_OK
@@ -71,7 +71,7 @@ func winrt_{{.Name}}_Release(instancePtr unsafe.Pointer) uint64 {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.
-		delete(callbacks{{.Name}}, instancePtr)
+		callbacks{{.Name}}.delete(instancePtr)
 		C.free(instancePtr)
 	}
 	return rem

--- a/windows/foundation/asyncoperationcompletedhandler_exports.go
+++ b/windows/foundation/asyncoperationcompletedhandler_exports.go
@@ -53,7 +53,7 @@ func winrt_AsyncOperationCompletedHandler_Invoke(instancePtr unsafe.Pointer, asy
 	instance := (*AsyncOperationCompletedHandler)(instancePtr)
 	asyncInfo := (*IAsyncOperation)(asyncInfoPtr)
 	asyncStatus := (AsyncStatus)(asyncStatusRaw)
-	if callback, ok := callbacksAsyncOperationCompletedHandler[instancePtr]; ok {
+	if callback, ok := callbacksAsyncOperationCompletedHandler.get(instancePtr); ok {
 		callback(instance, asyncInfo, asyncStatus)
 	}
 	return ole.S_OK
@@ -71,7 +71,7 @@ func winrt_AsyncOperationCompletedHandler_Release(instancePtr unsafe.Pointer) ui
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.
-		delete(callbacksAsyncOperationCompletedHandler, instancePtr)
+		callbacksAsyncOperationCompletedHandler.delete(instancePtr)
 		C.free(instancePtr)
 	}
 	return rem

--- a/windows/foundation/typedeventhandler_exports.go
+++ b/windows/foundation/typedeventhandler_exports.go
@@ -53,7 +53,7 @@ func winrt_TypedEventHandler_Invoke(instancePtr unsafe.Pointer, senderPtr unsafe
 	instance := (*TypedEventHandler)(instancePtr)
 	sender := (unsafe.Pointer)(senderPtr)
 	args := (unsafe.Pointer)(argsPtr)
-	if callback, ok := callbacksTypedEventHandler[instancePtr]; ok {
+	if callback, ok := callbacksTypedEventHandler.get(instancePtr); ok {
 		callback(instance, sender, args)
 	}
 	return ole.S_OK
@@ -71,7 +71,7 @@ func winrt_TypedEventHandler_Release(instancePtr unsafe.Pointer) uint64 {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.
-		delete(callbacksTypedEventHandler, instancePtr)
+		callbacksTypedEventHandler.delete(instancePtr)
 		C.free(instancePtr)
 	}
 	return rem


### PR DESCRIPTION
This could cause a `fatal error: concurrent map writes` when accessing the map from different goroutines.

fixes #72