### PR TITLE
codegen/delegate: initialize all fields after malloc

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -53,8 +53,11 @@ var callbacks{{.Name}} = &{{.Name | toLower}}CallbacksMap {
 
 func New{{.Name}}(iid *ole.GUID, callback {{.Name}}Callback) *{{.Name}} {
 	inst := (*{{.Name}})(C.malloc(C.size_t(unsafe.Sizeof({{.Name}}{}))))
+	// Override all properties: the malloc may contain garbage
 	inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_get{{.Name}}Vtbl()))
 	inst.IID = *iid // copy contents
+	inst.Mutex = sync.Mutex{}
+	inst.refs = 0
 
 	callbacks{{.Name}}.add(unsafe.Pointer(inst), callback)
 

--- a/windows/foundation/asyncoperationcompletedhandler.go
+++ b/windows/foundation/asyncoperationcompletedhandler.go
@@ -65,8 +65,11 @@ var callbacksAsyncOperationCompletedHandler = &asyncOperationCompletedHandlerCal
 
 func NewAsyncOperationCompletedHandler(iid *ole.GUID, callback AsyncOperationCompletedHandlerCallback) *AsyncOperationCompletedHandler {
 	inst := (*AsyncOperationCompletedHandler)(C.malloc(C.size_t(unsafe.Sizeof(AsyncOperationCompletedHandler{}))))
+	// Override all properties: the malloc may contain garbage
 	inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_getAsyncOperationCompletedHandlerVtbl()))
 	inst.IID = *iid // copy contents
+	inst.Mutex = sync.Mutex{}
+	inst.refs = 0
 
 	callbacksAsyncOperationCompletedHandler.add(unsafe.Pointer(inst), callback)
 

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -65,8 +65,11 @@ var callbacksTypedEventHandler = &typedEventHandlerCallbacksMap{
 
 func NewTypedEventHandler(iid *ole.GUID, callback TypedEventHandlerCallback) *TypedEventHandler {
 	inst := (*TypedEventHandler)(C.malloc(C.size_t(unsafe.Sizeof(TypedEventHandler{}))))
+	// Override all properties: the malloc may contain garbage
 	inst.RawVTable = (*interface{})((unsafe.Pointer)(C.winrt_getTypedEventHandlerVtbl()))
 	inst.IID = *iid // copy contents
+	inst.Mutex = sync.Mutex{}
+	inst.refs = 0
 
 	callbacksTypedEventHandler.add(unsafe.Pointer(inst), callback)
 


### PR DESCRIPTION
Otherwise their value may be contain garbage data when the memory is reused. This was causing random inconsistent mutex state errors.

fixes #71