### PR TITLE
codegen: add support for abstract classes

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -368,6 +368,7 @@ func (g *generator) createGenClass(typeDef *winmd.TypeDef) (*genClass, error) {
 		ImplInterfaces:      implInterfaces,
 		ExclusiveInterfaces: exclusiveGenInterfaces,
 		HasEmptyConstructor: hasEmptyConstructor,
+		IsAbstract:          typeDef.Flags.Abstract(),
 	}, nil
 }
 
@@ -1155,6 +1156,12 @@ func (g *generator) Signature(typeDef *winmd.TypeDef) (string, error) {
 
 		return fmt.Sprintf(`delegate({%s})`, guid), nil
 	case typeDef.IsRuntimeClass():
+		// Static only classes carry the abstract flag.
+		// These cannot be instantiated so no signature needed.
+		if typeDef.Flags.Abstract() {
+			return "", nil
+		}
+
 		// runtime_class_signature => "rc(" runtime_class_name ";" default_interface ")"
 
 		// Runtime classes must specify the DefaultAttribute on exactly one of their InterfaceImpl rows.

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -67,6 +67,7 @@ type genClass struct {
 	ImplInterfaces      []*genInterface
 	ExclusiveInterfaces []*genInterface
 	HasEmptyConstructor bool
+	IsAbstract          bool
 }
 
 func (g *genClass) GetRequiredImports() []*genImport {

--- a/internal/codegen/templates/class.tmpl
+++ b/internal/codegen/templates/class.tmpl
@@ -1,3 +1,4 @@
+{{if not .IsAbstract}}
 const Signature{{.Name}} string = "{{.Signature}}"
 
 type {{.Name}} struct {
@@ -12,6 +13,7 @@ func New{{.Name}}() (*{{.Name}}, error) {
     }
     return (*{{.Name}})(unsafe.Pointer(inspectable)), nil
 }
+{{end}}
 {{end}}
 
 {{$owner := .Name}}


### PR DESCRIPTION
Abstract classes only contain static methods (they implement a static interface) and the code generation was failing because we were trying to generate their signature. The signature is used to create new instances of generic classes, so we can skip its generation on abstract classes.

The commit also removes the class struct and its constructor, since they were unused.

fixes #79