### PR TITLE
codegen: change static func names to avoid conflicts

### DIFF
--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -143,14 +143,14 @@ type iBluetoothLEManufacturerDataFactory struct {
 type iBluetoothLEManufacturerDataFactoryVtbl struct {
 	ole.IInspectableVtbl
 
-	Create uintptr
+	BluetoothLEManufacturerDataCreate uintptr
 }
 
 func (v *iBluetoothLEManufacturerDataFactory) VTable() *iBluetoothLEManufacturerDataFactoryVtbl {
 	return (*iBluetoothLEManufacturerDataFactoryVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func Create(companyId uint16, data *streams.IBuffer) (*BluetoothLEManufacturerData, error) {
+func BluetoothLEManufacturerDataCreate(companyId uint16, data *streams.IBuffer) (*BluetoothLEManufacturerData, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Devices.Bluetooth.Advertisement.BluetoothLEManufacturerData", ole.NewGUID(GUIDiBluetoothLEManufacturerDataFactory))
 	if err != nil {
 		return nil, err
@@ -159,7 +159,7 @@ func Create(companyId uint16, data *streams.IBuffer) (*BluetoothLEManufacturerDa
 
 	var out *BluetoothLEManufacturerData
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().Create,
+		v.VTable().BluetoothLEManufacturerDataCreate,
 		0,                             // this is a static func, so there's no this
 		uintptr(companyId),            // in uint16
 		uintptr(unsafe.Pointer(data)), // in streams.IBuffer

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -272,20 +272,20 @@ type iBluetoothLEDeviceStatics2 struct {
 type iBluetoothLEDeviceStatics2Vtbl struct {
 	ole.IInspectableVtbl
 
-	GetDeviceSelectorFromPairingState                             uintptr
-	GetDeviceSelectorFromConnectionStatus                         uintptr
-	GetDeviceSelectorFromDeviceName                               uintptr
-	GetDeviceSelectorFromBluetoothAddress                         uintptr
-	GetDeviceSelectorFromBluetoothAddressWithBluetoothAddressType uintptr
-	GetDeviceSelectorFromAppearance                               uintptr
-	FromBluetoothAddressWithBluetoothAddressTypeAsync             uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromPairingState                             uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromConnectionStatus                         uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromDeviceName                               uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromBluetoothAddress                         uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromBluetoothAddressWithBluetoothAddressType uintptr
+	BluetoothLEDeviceGetDeviceSelectorFromAppearance                               uintptr
+	BluetoothLEDeviceFromBluetoothAddressWithBluetoothAddressTypeAsync             uintptr
 }
 
 func (v *iBluetoothLEDeviceStatics2) VTable() *iBluetoothLEDeviceStatics2Vtbl {
 	return (*iBluetoothLEDeviceStatics2Vtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func FromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoothAddress uint64, bluetoothAddressType BluetoothAddressType) (*foundation.IAsyncOperation, error) {
+func BluetoothLEDeviceFromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoothAddress uint64, bluetoothAddressType BluetoothAddressType) (*foundation.IAsyncOperation, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Devices.Bluetooth.BluetoothLEDevice", ole.NewGUID(GUIDiBluetoothLEDeviceStatics2))
 	if err != nil {
 		return nil, err
@@ -294,7 +294,7 @@ func FromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoothAddress uint64, 
 
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().FromBluetoothAddressWithBluetoothAddressTypeAsync,
+		v.VTable().BluetoothLEDeviceFromBluetoothAddressWithBluetoothAddressTypeAsync,
 		0,                             // this is a static func, so there's no this
 		uintptr(bluetoothAddress),     // in uint64
 		uintptr(bluetoothAddressType), // in BluetoothAddressType
@@ -318,16 +318,16 @@ type iBluetoothLEDeviceStatics struct {
 type iBluetoothLEDeviceStaticsVtbl struct {
 	ole.IInspectableVtbl
 
-	FromIdAsync               uintptr
-	FromBluetoothAddressAsync uintptr
-	GetDeviceSelector         uintptr
+	BluetoothLEDeviceFromIdAsync               uintptr
+	BluetoothLEDeviceFromBluetoothAddressAsync uintptr
+	BluetoothLEDeviceGetDeviceSelector         uintptr
 }
 
 func (v *iBluetoothLEDeviceStatics) VTable() *iBluetoothLEDeviceStaticsVtbl {
 	return (*iBluetoothLEDeviceStaticsVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func FromBluetoothAddressAsync(bluetoothAddress uint64) (*foundation.IAsyncOperation, error) {
+func BluetoothLEDeviceFromBluetoothAddressAsync(bluetoothAddress uint64) (*foundation.IAsyncOperation, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Devices.Bluetooth.BluetoothLEDevice", ole.NewGUID(GUIDiBluetoothLEDeviceStatics))
 	if err != nil {
 		return nil, err
@@ -336,7 +336,7 @@ func FromBluetoothAddressAsync(bluetoothAddress uint64) (*foundation.IAsyncOpera
 
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().FromBluetoothAddressAsync,
+		v.VTable().BluetoothLEDeviceFromBluetoothAddressAsync,
 		0,                             // this is a static func, so there's no this
 		uintptr(bluetoothAddress),     // in uint64
 		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation

--- a/windows/devices/bluetooth/genericattributeprofile/gattsession.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsession.go
@@ -194,14 +194,14 @@ type iGattSessionStatics struct {
 type iGattSessionStaticsVtbl struct {
 	ole.IInspectableVtbl
 
-	FromDeviceIdAsync uintptr
+	GattSessionFromDeviceIdAsync uintptr
 }
 
 func (v *iGattSessionStatics) VTable() *iGattSessionStaticsVtbl {
 	return (*iGattSessionStaticsVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func FromDeviceIdAsync(deviceId *bluetooth.BluetoothDeviceId) (*foundation.IAsyncOperation, error) {
+func GattSessionFromDeviceIdAsync(deviceId *bluetooth.BluetoothDeviceId) (*foundation.IAsyncOperation, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Devices.Bluetooth.GenericAttributeProfile.GattSession", ole.NewGUID(GUIDiGattSessionStatics))
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func FromDeviceIdAsync(deviceId *bluetooth.BluetoothDeviceId) (*foundation.IAsyn
 
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().FromDeviceIdAsync,
+		v.VTable().GattSessionFromDeviceIdAsync,
 		0,                                 // this is a static func, so there's no this
 		uintptr(unsafe.Pointer(deviceId)), // in bluetooth.BluetoothDeviceId
 		uintptr(unsafe.Pointer(&out)),     // out foundation.IAsyncOperation

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -49,14 +49,14 @@ type iBufferFactory struct {
 type iBufferFactoryVtbl struct {
 	ole.IInspectableVtbl
 
-	Create uintptr
+	BufferCreate uintptr
 }
 
 func (v *iBufferFactory) VTable() *iBufferFactoryVtbl {
 	return (*iBufferFactoryVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func Create(capacity uint32) (*Buffer, error) {
+func BufferCreate(capacity uint32) (*Buffer, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Storage.Streams.Buffer", ole.NewGUID(GUIDiBufferFactory))
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func Create(capacity uint32) (*Buffer, error) {
 
 	var out *Buffer
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().Create,
+		v.VTable().BufferCreate,
 		0,                             // this is a static func, so there's no this
 		uintptr(capacity),             // in uint32
 		uintptr(unsafe.Pointer(&out)), // out Buffer

--- a/windows/storage/streams/datareader.go
+++ b/windows/storage/streams/datareader.go
@@ -35,14 +35,14 @@ type iDataReaderStatics struct {
 type iDataReaderStaticsVtbl struct {
 	ole.IInspectableVtbl
 
-	FromBuffer uintptr
+	DataReaderFromBuffer uintptr
 }
 
 func (v *iDataReaderStatics) VTable() *iDataReaderStaticsVtbl {
 	return (*iDataReaderStaticsVtbl)(unsafe.Pointer(v.RawVTable))
 }
 
-func FromBuffer(buffer *IBuffer) (*DataReader, error) {
+func DataReaderFromBuffer(buffer *IBuffer) (*DataReader, error) {
 	inspectable, err := ole.RoGetActivationFactory("Windows.Storage.Streams.DataReader", ole.NewGUID(GUIDiDataReaderStatics))
 	if err != nil {
 		return nil, err
@@ -51,7 +51,7 @@ func FromBuffer(buffer *IBuffer) (*DataReader, error) {
 
 	var out *DataReader
 	hr, _, _ := syscall.SyscallN(
-		v.VTable().FromBuffer,
+		v.VTable().DataReaderFromBuffer,
 		0,                               // this is a static func, so there's no this
 		uintptr(unsafe.Pointer(buffer)), // in IBuffer
 		uintptr(unsafe.Pointer(&out)),   // out DataReader


### PR DESCRIPTION
Static functions were generated as public functions using the method name found in the windows metadata. Since all static functions of a namespace are added to the same Go package, this could cause collisions when two classes had the same static method (`FromBluetoothAddress` for example can be found in both Bluetoothdevice and BluetoothLEDevice).

This commit changes the naming strategy to include the class name as a prefix of the static function names. And the existing methods will be kept for a while marked as deprecated to maintain backwards compatibility.

fixes #85