### PR TITLE
sanity-check: validate generated code was not modified

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ include .go-builder/Makefile
 prepare: $(prepare_targets)
 
 .PHONY: sanity-check
-sanity-check: $(sanity_check_targets)
+sanity-check: $(sanity_check_targets) check-generated
 
 .PHONY: build
 build: $(build_targets)
@@ -27,6 +27,11 @@ clean: $(clean_targets)
 gen-files:
 	rm -rf $(CURDIR)/windows
 	go generate github.com/saltosystems/winrt-go/...
+
+.PHONY: check-generated
+check-generated: export WINRT_GO_GEN_VALIDATE=1
+check-generated:
+	 go generate github.com/saltosystems/winrt-go/...
 
 .PHONY: go-test
 go-test:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -26,6 +26,7 @@ func NewGenerateCommand(logger log.Logger) *subcommands.Command {
 	cfg := codegen.NewConfig()
 	fs := flag.NewFlagSet("winrt-go-gen", flag.ExitOnError)
 	_ = fs.String("config", "", "config file (optional)")
+	fs.BoolVar(&cfg.ValidateOnly, "validate", cfg.ValidateOnly, "validate the existing code instead of generating it")
 	fs.StringVar(&cfg.Class, "class", cfg.Class, "The class to generate. This should include the namespace and the class name, e.g. 'System.Runtime.InteropServices.WindowsRuntime.EventRegistrationToken'.")
 	fs.Func("method-filter", methodFilterUsage, func(m string) error {
 		cfg.AddMethodFilter(m)

--- a/internal/codegen/config.go
+++ b/internal/codegen/config.go
@@ -1,11 +1,14 @@
 package codegen
 
-import "fmt"
+import (
+	"fmt"
+)
 
 // Config is the configuration for the code generation.
 type Config struct {
 	Debug         bool
 	Class         string
+	ValidateOnly  bool
 	methodFilters []string
 }
 


### PR DESCRIPTION
Most PR we receive include new WinRT autogenerated classes. But that autogenerated code is hidden by GitHub when doing a review, so it is usually ignored by reviewers. By sanity-checking the generated code we make sure that the code was not manually modified (either by mistake or for malicious purposes).