### PR TITLE
codegen: fix generic input parameters

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -978,10 +978,12 @@ func (g *generator) elementType(ctx *types.Context, e types.Element) (*genParamT
 			defaultValue:       g.elementDefaultValue(ctx, e),
 		}, nil
 	case types.ELEMENT_TYPE_VAR:
-		// A class variable type modifier
+		// Generic types are not fully supported yet,
+		// so we will just pass the raw unsafe.Pointer up to the user.
 		return &genParamType{
 			namespace:    "unsafe",
 			name:         "Pointer",
+			IsGeneric:    true,
 			IsPointer:    false,
 			IsPrimitive:  false,
 			IsArray:      false,

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -147,6 +147,7 @@ type genParamType struct {
 	name      string
 
 	IsPointer          bool
+	IsGeneric          bool
 	IsArray            bool
 	IsPrimitive        bool
 	IsEnum             bool

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -63,6 +63,8 @@ hr, _, _ := syscall.SyscallN(
             {{else -}}
                 uintptr({{.GoVarName}}),   // in {{.GoTypeName}}
             {{end -}}
+        {{else if .Type.IsGeneric -}}
+            uintptr({{.GoVarName}}),   // in {{.GoTypeName}}
         {{else -}}
             uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoTypeName}}
         {{end -}}

--- a/windows/foundation/collections/ivector.go
+++ b/windows/foundation/collections/ivector.go
@@ -92,7 +92,7 @@ func (v *IVector) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
+		uintptr(value),                  // in unsafe.Pointer
 		uintptr(unsafe.Pointer(&index)), // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)
@@ -107,9 +107,9 @@ func (v *IVector) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
 func (v *IVector) SetAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().SetAt,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(index),                  // in uint32
-		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(index),             // in uint32
+		uintptr(value),             // in unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -122,9 +122,9 @@ func (v *IVector) SetAt(index uint32, value unsafe.Pointer) error {
 func (v *IVector) InsertAt(index uint32, value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().InsertAt,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(index),                  // in uint32
-		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(index),             // in uint32
+		uintptr(value),             // in unsafe.Pointer
 	)
 
 	if hr != 0 {
@@ -151,8 +151,8 @@ func (v *IVector) RemoveAt(index uint32) error {
 func (v *IVector) Append(value unsafe.Pointer) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().Append,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
+		uintptr(unsafe.Pointer(v)), // this
+		uintptr(value),             // in unsafe.Pointer
 	)
 
 	if hr != 0 {

--- a/windows/foundation/collections/ivectorview.go
+++ b/windows/foundation/collections/ivectorview.go
@@ -69,7 +69,7 @@ func (v *IVectorView) IndexOf(value unsafe.Pointer) (uint32, bool, error) {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().IndexOf,
 		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer
+		uintptr(value),                  // in unsafe.Pointer
 		uintptr(unsafe.Pointer(&index)), // out uint32
 		uintptr(unsafe.Pointer(&out)),   // out bool
 	)


### PR DESCRIPTION
Generic parameters are not yet supported so we use the unsafe.Pointer to let the user pass any parameter it wants. We were not taking this into account on function input parameters and we were wraping the unsafe.Pointer value again in another unsafe.Pointer, which caused errors for some users.

fixes #92