### PR TITLE
delegates: allocate VTable in heap

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -29,21 +29,29 @@ var releaseChannels{{.Name}} = &{{.Name | toLower}}ReleaseChannels {
 }
 
 func New{{.Name}}(iid *ole.GUID, callback {{.Name}}Callback) *{{.Name}} {
+	// create type instance
 	size := unsafe.Sizeof(*(*{{.Name}})(nil))
 	instPtr := kernel32.Malloc(size)
 	inst := (*{{.Name}})(instPtr)
 	
+	// get the callbacks for the VTable
 	callbacks := delegate.RegisterCallbacks(instPtr, inst)
 
-	// Initialize all properties: the malloc may contain garbage
-	inst.RawVTable = (*interface{})(unsafe.Pointer(&{{.Name}}Vtbl{
-		IUnknownVtbl: ole.IUnknownVtbl{
+	// the VTable should also be allocated in the heap
+	sizeVTable := unsafe.Sizeof(*(*{{.Name}}Vtbl)(nil))
+	vTablePtr := kernel32.Malloc(sizeVTable)
+
+	inst.RawVTable = (*interface{})(vTablePtr)
+	
+	vTable := (*{{.Name}}Vtbl)(vTablePtr)
+	vTable.IUnknownVtbl = ole.IUnknownVtbl{
 			QueryInterface: callbacks.QueryInterface,
 			AddRef:         callbacks.AddRef,
 			Release:        callbacks.Release,
-		},
-		Invoke: callbacks.Invoke,
-	}))
+	}
+	vTable.Invoke = callbacks.Invoke
+
+	// Initialize all properties: the malloc may contain garbage
 	inst.IID = *iid // copy contents
 	inst.Mutex = sync.Mutex{}
 	inst.refs = 0
@@ -119,6 +127,7 @@ func (instance *{{.Name}}) Release() uint64 {
 		// https://github.com/golang/go/issues/55015
 		releaseChannels{{.Name}}.release(instancePtr)
 
+		kernel32.Free(unsafe.Pointer(instance.RawVTable))
 		kernel32.Free(instancePtr)
 	}
 	return rem

--- a/windows/foundation/asyncoperationcompletedhandler.go
+++ b/windows/foundation/asyncoperationcompletedhandler.go
@@ -43,21 +43,29 @@ var releaseChannelsAsyncOperationCompletedHandler = &asyncOperationCompletedHand
 }
 
 func NewAsyncOperationCompletedHandler(iid *ole.GUID, callback AsyncOperationCompletedHandlerCallback) *AsyncOperationCompletedHandler {
+	// create type instance
 	size := unsafe.Sizeof(*(*AsyncOperationCompletedHandler)(nil))
 	instPtr := kernel32.Malloc(size)
 	inst := (*AsyncOperationCompletedHandler)(instPtr)
 
+	// get the callbacks for the VTable
 	callbacks := delegate.RegisterCallbacks(instPtr, inst)
 
+	// the VTable should also be allocated in the heap
+	sizeVTable := unsafe.Sizeof(*(*AsyncOperationCompletedHandlerVtbl)(nil))
+	vTablePtr := kernel32.Malloc(sizeVTable)
+
+	inst.RawVTable = (*interface{})(vTablePtr)
+
+	vTable := (*AsyncOperationCompletedHandlerVtbl)(vTablePtr)
+	vTable.IUnknownVtbl = ole.IUnknownVtbl{
+		QueryInterface: callbacks.QueryInterface,
+		AddRef:         callbacks.AddRef,
+		Release:        callbacks.Release,
+	}
+	vTable.Invoke = callbacks.Invoke
+
 	// Initialize all properties: the malloc may contain garbage
-	inst.RawVTable = (*interface{})(unsafe.Pointer(&AsyncOperationCompletedHandlerVtbl{
-		IUnknownVtbl: ole.IUnknownVtbl{
-			QueryInterface: callbacks.QueryInterface,
-			AddRef:         callbacks.AddRef,
-			Release:        callbacks.Release,
-		},
-		Invoke: callbacks.Invoke,
-	}))
 	inst.IID = *iid // copy contents
 	inst.Mutex = sync.Mutex{}
 	inst.refs = 0
@@ -123,6 +131,7 @@ func (instance *AsyncOperationCompletedHandler) Release() uint64 {
 		// https://github.com/golang/go/issues/55015
 		releaseChannelsAsyncOperationCompletedHandler.release(instancePtr)
 
+		kernel32.Free(unsafe.Pointer(instance.RawVTable))
 		kernel32.Free(instancePtr)
 	}
 	return rem

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -43,21 +43,29 @@ var releaseChannelsTypedEventHandler = &typedEventHandlerReleaseChannels{
 }
 
 func NewTypedEventHandler(iid *ole.GUID, callback TypedEventHandlerCallback) *TypedEventHandler {
+	// create type instance
 	size := unsafe.Sizeof(*(*TypedEventHandler)(nil))
 	instPtr := kernel32.Malloc(size)
 	inst := (*TypedEventHandler)(instPtr)
 
+	// get the callbacks for the VTable
 	callbacks := delegate.RegisterCallbacks(instPtr, inst)
 
+	// the VTable should also be allocated in the heap
+	sizeVTable := unsafe.Sizeof(*(*TypedEventHandlerVtbl)(nil))
+	vTablePtr := kernel32.Malloc(sizeVTable)
+
+	inst.RawVTable = (*interface{})(vTablePtr)
+
+	vTable := (*TypedEventHandlerVtbl)(vTablePtr)
+	vTable.IUnknownVtbl = ole.IUnknownVtbl{
+		QueryInterface: callbacks.QueryInterface,
+		AddRef:         callbacks.AddRef,
+		Release:        callbacks.Release,
+	}
+	vTable.Invoke = callbacks.Invoke
+
 	// Initialize all properties: the malloc may contain garbage
-	inst.RawVTable = (*interface{})(unsafe.Pointer(&TypedEventHandlerVtbl{
-		IUnknownVtbl: ole.IUnknownVtbl{
-			QueryInterface: callbacks.QueryInterface,
-			AddRef:         callbacks.AddRef,
-			Release:        callbacks.Release,
-		},
-		Invoke: callbacks.Invoke,
-	}))
 	inst.IID = *iid // copy contents
 	inst.Mutex = sync.Mutex{}
 	inst.refs = 0
@@ -123,6 +131,7 @@ func (instance *TypedEventHandler) Release() uint64 {
 		// https://github.com/golang/go/issues/55015
 		releaseChannelsTypedEventHandler.release(instancePtr)
 
+		kernel32.Free(unsafe.Pointer(instance.RawVTable))
 		kernel32.Free(instancePtr)
 	}
 	return rem


### PR DESCRIPTION
The VTable is a field all WinRT types have and it is used to store pointers to all the class functions. This field is usually created by WinRT, but for delegates we need to provide our own VTable instance.

We were previously using a Go struct pointer as our VTable, but Go structs can be randomly moved or GCed by the Go runtime, and since we are pasing the VTable to WinRT (out of the Go runtime), we were getting random invalid memory errors.

This was addressed in a previous PR (#64) but somehow we missed this.

fixes #94