### PR TITLE
delegate: return uintptr as callback result

### DIFF
--- a/internal/codegen/templates/delegate.tmpl
+++ b/internal/codegen/templates/delegate.tmpl
@@ -5,7 +5,7 @@ const Signature{{.Name}} string = "{{.Signature}}"
 type {{.Name}} struct {
 	ole.IUnknown
 	sync.Mutex
-	refs uint64
+	refs uintptr
 	IID  ole.GUID
 }
 
@@ -70,7 +70,7 @@ func (r *{{.Name}}) GetIID() *ole.GUID {
 }
 
 // addRef increments the reference counter by one
-func (r *{{.Name}}) addRef() uint64 {
+func (r *{{.Name}}) addRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 	r.refs++
@@ -78,7 +78,7 @@ func (r *{{.Name}}) addRef() uint64 {
 }
 
 // removeRef decrements the reference counter by one. If it was already zero, it will just return zero.
-func (r *{{.Name}}) removeRef() uint64 {
+func (r *{{.Name}}) removeRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 
@@ -112,11 +112,11 @@ func (instance *{{.Name}}) Invoke(instancePtr, rawArgs0, rawArgs1, rawArgs2, raw
 	return ole.S_OK
 }
 
-func (instance *{{.Name}}) AddRef() uint64 {
+func (instance *{{.Name}}) AddRef() uintptr {
 	return instance.addRef()
 }
 
-func (instance *{{.Name}}) Release() uint64 {
+func (instance *{{.Name}}) Release() uintptr {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.

--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -24,8 +24,8 @@ var (
 type Delegate interface {
 	GetIID() *ole.GUID
 	Invoke(instancePtr, rawArgs0, rawArgs1, rawArgs2, rawArgs3, rawArgs4, rawArgs5, rawArgs6, rawArgs7, rawArgs8 unsafe.Pointer) uintptr
-	AddRef() uint64
-	Release() uint64
+	AddRef() uintptr
+	Release() uintptr
 }
 
 // Callbacks contains the syscalls registered on Windows.
@@ -113,7 +113,7 @@ func invoke(instancePtr, rawArgs0, rawArgs1, rawArgs2, rawArgs3, rawArgs4, rawAr
 	return instance.Invoke(instancePtr, rawArgs0, rawArgs1, rawArgs2, rawArgs3, rawArgs4, rawArgs5, rawArgs6, rawArgs7, rawArgs8)
 }
 
-func addRef(instancePtr unsafe.Pointer) uint64 {
+func addRef(instancePtr unsafe.Pointer) uintptr {
 	instance, ok := getInstance(instancePtr)
 	if !ok {
 		// instance not found
@@ -123,7 +123,7 @@ func addRef(instancePtr unsafe.Pointer) uint64 {
 	return instance.AddRef()
 }
 
-func release(instancePtr unsafe.Pointer) uint64 {
+func release(instancePtr unsafe.Pointer) uintptr {
 	instance, ok := getInstance(instancePtr)
 	if !ok {
 		// instance not found

--- a/windows/foundation/asyncoperationcompletedhandler.go
+++ b/windows/foundation/asyncoperationcompletedhandler.go
@@ -21,7 +21,7 @@ const SignatureAsyncOperationCompletedHandler string = "delegate({fcdcf02c-e5d8-
 type AsyncOperationCompletedHandler struct {
 	ole.IUnknown
 	sync.Mutex
-	refs uint64
+	refs uintptr
 	IID  ole.GUID
 }
 
@@ -84,7 +84,7 @@ func (r *AsyncOperationCompletedHandler) GetIID() *ole.GUID {
 }
 
 // addRef increments the reference counter by one
-func (r *AsyncOperationCompletedHandler) addRef() uint64 {
+func (r *AsyncOperationCompletedHandler) addRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 	r.refs++
@@ -92,7 +92,7 @@ func (r *AsyncOperationCompletedHandler) addRef() uint64 {
 }
 
 // removeRef decrements the reference counter by one. If it was already zero, it will just return zero.
-func (r *AsyncOperationCompletedHandler) removeRef() uint64 {
+func (r *AsyncOperationCompletedHandler) removeRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 
@@ -116,11 +116,11 @@ func (instance *AsyncOperationCompletedHandler) Invoke(instancePtr, rawArgs0, ra
 	return ole.S_OK
 }
 
-func (instance *AsyncOperationCompletedHandler) AddRef() uint64 {
+func (instance *AsyncOperationCompletedHandler) AddRef() uintptr {
 	return instance.addRef()
 }
 
-func (instance *AsyncOperationCompletedHandler) Release() uint64 {
+func (instance *AsyncOperationCompletedHandler) Release() uintptr {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.

--- a/windows/foundation/deferralcompletedhandler.go
+++ b/windows/foundation/deferralcompletedhandler.go
@@ -21,7 +21,7 @@ const SignatureDeferralCompletedHandler string = "delegate({ed32a372-f3c8-4faa-9
 type DeferralCompletedHandler struct {
 	ole.IUnknown
 	sync.Mutex
-	refs uint64
+	refs uintptr
 	IID  ole.GUID
 }
 
@@ -84,7 +84,7 @@ func (r *DeferralCompletedHandler) GetIID() *ole.GUID {
 }
 
 // addRef increments the reference counter by one
-func (r *DeferralCompletedHandler) addRef() uint64 {
+func (r *DeferralCompletedHandler) addRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 	r.refs++
@@ -92,7 +92,7 @@ func (r *DeferralCompletedHandler) addRef() uint64 {
 }
 
 // removeRef decrements the reference counter by one. If it was already zero, it will just return zero.
-func (r *DeferralCompletedHandler) removeRef() uint64 {
+func (r *DeferralCompletedHandler) removeRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 
@@ -112,11 +112,11 @@ func (instance *DeferralCompletedHandler) Invoke(instancePtr, rawArgs0, rawArgs1
 	return ole.S_OK
 }
 
-func (instance *DeferralCompletedHandler) AddRef() uint64 {
+func (instance *DeferralCompletedHandler) AddRef() uintptr {
 	return instance.addRef()
 }
 
-func (instance *DeferralCompletedHandler) Release() uint64 {
+func (instance *DeferralCompletedHandler) Release() uintptr {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.

--- a/windows/foundation/typedeventhandler.go
+++ b/windows/foundation/typedeventhandler.go
@@ -21,7 +21,7 @@ const SignatureTypedEventHandler string = "delegate({9de1c534-6ae1-11e0-84e1-18a
 type TypedEventHandler struct {
 	ole.IUnknown
 	sync.Mutex
-	refs uint64
+	refs uintptr
 	IID  ole.GUID
 }
 
@@ -84,7 +84,7 @@ func (r *TypedEventHandler) GetIID() *ole.GUID {
 }
 
 // addRef increments the reference counter by one
-func (r *TypedEventHandler) addRef() uint64 {
+func (r *TypedEventHandler) addRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 	r.refs++
@@ -92,7 +92,7 @@ func (r *TypedEventHandler) addRef() uint64 {
 }
 
 // removeRef decrements the reference counter by one. If it was already zero, it will just return zero.
-func (r *TypedEventHandler) removeRef() uint64 {
+func (r *TypedEventHandler) removeRef() uintptr {
 	r.Lock()
 	defer r.Unlock()
 
@@ -116,11 +116,11 @@ func (instance *TypedEventHandler) Invoke(instancePtr, rawArgs0, rawArgs1, rawAr
 	return ole.S_OK
 }
 
-func (instance *TypedEventHandler) AddRef() uint64 {
+func (instance *TypedEventHandler) AddRef() uintptr {
 	return instance.addRef()
 }
 
-func (instance *TypedEventHandler) Release() uint64 {
+func (instance *TypedEventHandler) Release() uintptr {
 	rem := instance.removeRef()
 	if rem == 0 {
 		// We're done.


### PR DESCRIPTION
According to the syscall.NewCallback docs all the callbacks should return an uintptr sized result. But we were previously using uint64 which only works for 64 bit systems. This change should allow using winrt-go on 32 bit windows devices.

fixes #83