### PR TITLE
*: add activation factory ref to static methods

### DIFF
--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -34,11 +34,7 @@ v := (*{{.FuncOwner}})(unsafe.Pointer(inspectable))
 {{ end -}}
 hr, _, _ := syscall.SyscallN(
     v.VTable().{{funcName .}},
-    {{- if .RequiresActivation}}
-        0, // this is a static func, so there's no this
-    {{else}}
-        uintptr(unsafe.Pointer(v)), // this
-    {{end -}}
+    uintptr(unsafe.Pointer(v)), // this
     {{range (concat .InParams .ReturnParams) -}}
         {{if .Type.IsArray -}}
             {{/* Arrays need to pass a pointer to their first element */ -}}

--- a/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothlemanufacturerdata.go
@@ -160,7 +160,7 @@ func BluetoothLEManufacturerDataCreate(companyId uint16, data *streams.IBuffer) 
 	var out *BluetoothLEManufacturerData
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().BluetoothLEManufacturerDataCreate,
-		0,                             // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),    // this
 		uintptr(companyId),            // in uint16
 		uintptr(unsafe.Pointer(data)), // in streams.IBuffer
 		uintptr(unsafe.Pointer(&out)), // out BluetoothLEManufacturerData

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -318,7 +318,7 @@ func BluetoothLEDeviceFromBluetoothAddressWithBluetoothAddressTypeAsync(bluetoot
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().BluetoothLEDeviceFromBluetoothAddressWithBluetoothAddressTypeAsync,
-		0,                             // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),    // this
 		uintptr(bluetoothAddress),     // in uint64
 		uintptr(bluetoothAddressType), // in BluetoothAddressType
 		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
@@ -360,7 +360,7 @@ func BluetoothLEDeviceFromBluetoothAddressAsync(bluetoothAddress uint64) (*found
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().BluetoothLEDeviceFromBluetoothAddressAsync,
-		0,                             // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),    // this
 		uintptr(bluetoothAddress),     // in uint64
 		uintptr(unsafe.Pointer(&out)), // out foundation.IAsyncOperation
 	)

--- a/windows/devices/bluetooth/genericattributeprofile/gattserviceprovider.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattserviceprovider.go
@@ -218,7 +218,7 @@ func GattServiceProviderCreateAsync(serviceUuid syscall.GUID) (*foundation.IAsyn
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GattServiceProviderCreateAsync,
-		0,                                     // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),            // this
 		uintptr(unsafe.Pointer(&serviceUuid)), // in syscall.GUID
 		uintptr(unsafe.Pointer(&out)),         // out foundation.IAsyncOperation
 	)

--- a/windows/devices/bluetooth/genericattributeprofile/gattsession.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsession.go
@@ -211,7 +211,7 @@ func GattSessionFromDeviceIdAsync(deviceId *bluetooth.BluetoothDeviceId) (*found
 	var out *foundation.IAsyncOperation
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().GattSessionFromDeviceIdAsync,
-		0,                                 // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),        // this
 		uintptr(unsafe.Pointer(deviceId)), // in bluetooth.BluetoothDeviceId
 		uintptr(unsafe.Pointer(&out)),     // out foundation.IAsyncOperation
 	)

--- a/windows/foundation/deferral.go
+++ b/windows/foundation/deferral.go
@@ -89,7 +89,7 @@ func DeferralCreate(handler *DeferralCompletedHandler) (*Deferral, error) {
 	var out *Deferral
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().DeferralCreate,
-		0,                                // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),       // this
 		uintptr(unsafe.Pointer(handler)), // in DeferralCompletedHandler
 		uintptr(unsafe.Pointer(&out)),    // out Deferral
 	)

--- a/windows/storage/streams/buffer.go
+++ b/windows/storage/streams/buffer.go
@@ -66,7 +66,7 @@ func BufferCreate(capacity uint32) (*Buffer, error) {
 	var out *Buffer
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().BufferCreate,
-		0,                             // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),    // this
 		uintptr(capacity),             // in uint32
 		uintptr(unsafe.Pointer(&out)), // out Buffer
 	)

--- a/windows/storage/streams/datareader.go
+++ b/windows/storage/streams/datareader.go
@@ -52,7 +52,7 @@ func DataReaderFromBuffer(buffer *IBuffer) (*DataReader, error) {
 	var out *DataReader
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().DataReaderFromBuffer,
-		0,                               // this is a static func, so there's no this
+		uintptr(unsafe.Pointer(v)),      // this
 		uintptr(unsafe.Pointer(buffer)), // in IBuffer
 		uintptr(unsafe.Pointer(&out)),   // out DataReader
 	)


### PR DESCRIPTION
I could not find any mention to this in the documentation, but it seems like some static methods fail unless we pass a reference to their activation factory. The Rust projection of WinRT does this.

See: https://github.com/microsoft/windows-rs/blob/f19edde93252381b7a1789bf856a3a67df23f6db/crates/libs/windows/src/Windows/Storage/mod.rs#L3665C76-L3665C112

fixes #97