### PR TITLE
Fix enum generation by moving to a maintained win32metadata

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,12 @@ require (
 	github.com/go-ole/go-ole v1.2.6
 	github.com/peterbourgon/ff/v3 v3.1.2
 	github.com/stretchr/testify v1.7.5
-	github.com/tdakkota/win32metadata v0.1.0
 	golang.org/x/sys v0.0.0-20220624220833-87e55d714810
 	golang.org/x/tools v0.1.11
 )
 
 require (
+	github.com/TotallyGamerJet/win32metadata v0.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/TotallyGamerJet/win32metadata v0.1.1 h1:BbVJMzGqvbV7e/qGaMwhwlYy+7uCxRyS8N5Cdf9iTGs=
+github.com/TotallyGamerJet/win32metadata v0.1.1/go.mod h1:n8CvXIiJzb60/L2al9ZzQipdkREdmNHrm2T0F/31dwk=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -20,8 +22,6 @@ github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSS
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.5 h1:s5PTfem8p8EbKQOctVV53k6jCJt3UX4IEJzwh+C324Q=
 github.com/stretchr/testify v1.7.5/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/tdakkota/win32metadata v0.1.0 h1:0xoy5sPaOy8QDRc16hdvuFD4suyCVO2m37V8zdIk2kI=
-github.com/tdakkota/win32metadata v0.1.0/go.mod h1:77e6YvX0LIVW+O81fhWLnXAxxcyu/wdZdG7iwed7Fyk=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=

--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-kit/log/level"
 	"github.com/saltosystems/winrt-go"
 	"github.com/saltosystems/winrt-go/internal/winmd"
-	"github.com/tdakkota/win32metadata/types"
+	"github.com/TotallyGamerJet/win32metadata/types"
 	"golang.org/x/tools/imports"
 )
 

--- a/internal/winmd/methoddef.go
+++ b/internal/winmd/methoddef.go
@@ -1,8 +1,8 @@
 package winmd
 
 import (
-	"github.com/tdakkota/win32metadata/md"
-	"github.com/tdakkota/win32metadata/types"
+	"github.com/TotallyGamerJet/win32metadata/md"
+	"github.com/TotallyGamerJet/win32metadata/types"
 )
 
 // GetMethodOverloadName finds and returns the overload attribute for the given method

--- a/internal/winmd/store.go
+++ b/internal/winmd/store.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/go-kit/log"
-	"github.com/tdakkota/win32metadata/md"
-	"github.com/tdakkota/win32metadata/types"
+	"github.com/TotallyGamerJet/win32metadata/md"
+	"github.com/TotallyGamerJet/win32metadata/types"
 )
 
 // ClassNotFoundError is returned when a class is not found.

--- a/internal/winmd/typedef.go
+++ b/internal/winmd/typedef.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
-	"github.com/tdakkota/win32metadata/md"
-	"github.com/tdakkota/win32metadata/types"
+	"github.com/TotallyGamerJet/win32metadata/md"
+	"github.com/TotallyGamerJet/win32metadata/types"
 )
 
 // TypeDef is a helper struct that wraps types.TypeDef and stores the original context

--- a/internal/winmd/winmd.go
+++ b/internal/winmd/winmd.go
@@ -7,7 +7,7 @@ import (
 	"io/fs"
 	"io/ioutil"
 
-	"github.com/tdakkota/win32metadata/types"
+	"github.com/TotallyGamerJet/win32metadata/types"
 )
 
 // Custom Attributes


### PR DESCRIPTION
Generating anything that touches a `Windows.UI.Xaml` enum currently fails:

```
$ go run ./cmd/winrt-go-gen -class Windows.UI.Xaml.Controls.Orientation
level=error err="decode field Value: EOF"

$ go run ./cmd/winrt-go-gen -class Windows.UI.Xaml.FrameworkElement -method-filter put_HorizontalAlignment
level=error err="decode field Value: EOF"
```

The second case is the painful one: a single enum-typed member aborts generation of its entire class, which rules out most of `Windows.UI.Xaml`.

## Cause

The metadata reader sizes the `HasConstant` composite index from the wrong tables. ECMA-335 II.24.2.6 defines it over **Field, Param, Property**, but `computeIndexes` uses **TypeDef, TypeRef, Property**. Every other composite index in that function is correct, so it reads as a copy-paste from `typeDefOrRef` immediately above it.

The two sets only disagree when exactly one of them crosses the 2^14 row limit that widens a three-table composite index from two bytes to four. Of the twenty bundled winmd files, exactly one does:

| winmd | Field | Param | Property | TypeDef | TypeRef | correct | computed |
|---|---|---|---|---|---|---|---|
| `Windows.UI.Xaml.winmd` | 3602 | **21293** | 9371 | 3323 | 3476 | 4 | 2 |
| all 19 others | | | | | | 2 | 2 |

So `Windows.UI.Xaml.winmd`'s `Constant` table is read two bytes too narrow, which misaligns every table stored after it. Only 1295 of its 3312 `Constant` rows decode, and enum values cannot be resolved at all. Every other winmd is unaffected, which is why this went unnoticed.

## Why the dependency changes

`github.com/tdakkota/win32metadata` cannot take the fix — **the repository no longer exists on GitHub**. `gh repo view` returns "Could not resolve to a Repository"; the user is still active with 11 public repos and none is a rename of it. The module only still resolves because proxy.golang.org caches it immutably. So this project currently depends on a library that can no longer receive a patch.

`github.com/TotallyGamerJet/win32metadata` is a continuation of it:

- first commit is a **verbatim copy of `v0.1.0`** taken from the Go proxy
- second renames the module path, since the fix has to live somewhere resolvable
- third is the one-line fix plus a regression test

The original MIT license and copyright are unchanged, and provenance is recorded in the README. Released as [v0.1.1](https://github.com/TotallyGamerJet/win32metadata/releases/tag/v0.1.1).

## Verification

- **`go generate ./...` reproduces the committed `windows/` tree byte-for-byte.** No regressions in existing output.
- `go test ./...` passes here and in the dependency.
- The enums that previously failed now generate with values matching the documented WinRT definitions:

```go
OrientationVertical   Orientation = 0    HorizontalAlignmentLeft    HorizontalAlignment = 0
OrientationHorizontal Orientation = 1    HorizontalAlignmentCenter  HorizontalAlignment = 1
                                         HorizontalAlignmentRight   HorizontalAlignment = 2
VisibilityVisible  Visibility = 0        HorizontalAlignmentStretch HorizontalAlignment = 3
VisibilityCollapsed Visibility = 1
```

- The regression test is synthetic rather than testdata-driven, because neither winmd bundled with the parser exposes the bug.

The diff here is 11 lines, all import paths.

## Notes

Depending on a personal fork may not be what you want, and that's reasonable. Happy to transfer the repository to the `saltosystems` org, or to re-point this at any other home you'd prefer — the important part is the two-line fix, not who hosts it.

I also evaluated [microsoft/go-winmd](https://github.com/microsoft/go-winmd) as a maintained replacement, since it gets `HasConstant` right by construction. It can't work yet: its signature decoder rejects `GENERICINST`, `SZARRAY` and `VAR`, which fails 11444 of 70003 method signatures across these winmd files (10754 from generics alone). [microsoft/go-winmd#19](https://github.com/microsoft/go-winmd/issues/19) has been open since January 2023. Worth revisiting if that lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
