### PR TITLE
Pass object parameters by value, not by address

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -1004,10 +1004,15 @@ func (g *generator) elementType(ctx *types.Context, e types.Element) (*genParamT
 
 		return param, err
 	case types.ELEMENT_TYPE_OBJECT:
-		// This represents System.Object, so just use a pointer
+		// This represents System.Object, so just use a pointer.
+		//
+		// IsGeneric marks it as already being a pointer, so that it is passed
+		// straight through rather than having its address taken, the same way
+		// ELEMENT_TYPE_VAR is handled above.
 		return &genParamType{
 			namespace:    "unsafe",
 			name:         "Pointer",
+			IsGeneric:    true,
 			IsPointer:    false,
 			IsPrimitive:  false,
 			IsArray:      false,


### PR DESCRIPTION
Generating a class with an `object`-typed parameter produces a call that crashes the process rather than working or failing cleanly.

`Windows.UI.Xaml.Controls.ContentControl.Content` is the easiest way to hit it — it's what every `Button` label goes through:

```go
func (v *iContentControl) SetContent(value unsafe.Pointer) error {
	hr, _, _ := syscall.SyscallN(
		v.VTable().SetContent,
		uintptr(unsafe.Pointer(v)),      // this
		uintptr(unsafe.Pointer(&value)), // in unsafe.Pointer   <-- address of the local
	)
```

`value` is already the interface pointer WinRT wants. Taking its address hands the callee a pointer to a Go local, which it then dereferences as an `IInspectable` vtable. In practice that means:

```
exit=-1073740791   (0xC0000409, STATUS_STACK_BUFFER_OVERRUN)
```

No HRESULT, no Go panic — control has already transferred through a garbage vtable.

## Fix

The marshalling cascade in `funcimpl.tmpl` keys off `IsGeneric` for exactly this situation:

```
{{else if .Type.IsGeneric -}}
    uintptr({{.GoVarName}}),   // in {{.GoTypeName}}
```

`ELEMENT_TYPE_VAR` already sets it, because its value is itself a pointer and has to pass straight through. `ELEMENT_TYPE_OBJECT` is projected as `unsafe.Pointer` too, but set neither `IsGeneric` nor `IsPointer`, so it fell through to the final `else` that takes an address. This sets `IsGeneric` on it to match.

`IsGeneric` is read in that one template branch and nowhere else, so the declared Go type is unaffected — the parameter stays `unsafe.Pointer`.

## Verification

- **`go generate ./...` leaves every committed file under `windows/` unchanged.** None of the classes generated today has an `object` in-parameter, so this cannot regress existing output.
- With the fix, `ContentControl.SetContent` emits `uintptr(value)` and setting a `Button`'s content works.
- `go test ./...` passes.

Independent of #121 and applies cleanly on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
