### PR TITLE
Import internal/delegate from the file template

### DIFF
--- a/internal/codegen/templates/file.tmpl
+++ b/internal/codegen/templates/file.tmpl
@@ -10,6 +10,7 @@ import (
 	"unsafe"
 	"github.com/go-ole/go-ole"
 	"github.com/saltosystems/winrt-go"
+	"github.com/saltosystems/winrt-go/internal/delegate"
 	"github.com/saltosystems/winrt-go/internal/kernel32"
 	{{range .Imports}}"{{.}}"
 	{{end}}


### PR DESCRIPTION
Delegates only generate correctly into `windows/foundation`. Generating one into any other package emits a file that uses `delegate.RegisterCallbacks` without importing it:

```
$ go run ./cmd/winrt-go-gen -class Windows.UI.Xaml.RoutedEventHandler
$ GOOS=windows go build ./...
windows/ui/xaml/routedeventhandler.go:51:15: undefined: delegate
```

`file.tmpl` hardcodes `internal/kernel32` but leaves `internal/delegate` for goimports to add. That resolves for `windows/foundation` — which is why every committed delegate is fine and this went unnoticed — but not for a delegate generated elsewhere. It reproduces on a fresh checkout with the single command above.

Hardcoding both makes it deterministic and matches how `kernel32` is already handled. Unused imports are stripped by the goimports pass that follows, so non-delegate files are unaffected — exactly as they are today with `kernel32`, which is hardcoded and absent from, say, `grid.go`.

## Verification

- **Every committed file under `windows/` regenerates byte-identically**, including the existing delegates in `windows/foundation`.
- `GOOS=windows go build ./...` is clean, and `Windows.UI.Xaml.RoutedEventHandler` now compiles where it previously did not.
- `go test ./...` passes.

Independent of #121 and #122; applies cleanly on its own.

Worth noting the related limitation this doesn't address: because these helpers live under `internal/`, a generated delegate can only ever compile inside this module — anyone running `winrt-go-gen` against their own module gets code Go refuses to build. That's arguably working as intended given the README invites new APIs here rather than downstream, so I've left it alone; happy to open a separate discussion if you'd like delegates to be usable out-of-tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
