### PR TITLE
Pass small structs by value, not by address

### DIFF
--- a/internal/codegen/codegen.go
+++ b/internal/codegen/codegen.go
@@ -466,6 +466,69 @@ func (g *generator) createGenEnum(typeDef *winmd.TypeDef) (*genEnum, error) {
 }
 
 // https://docs.microsoft.com/en-us/uwp/winrt-cref/winmd-files#structs
+// goTypeSizes gives the width in bytes of the Go types the generator emits for
+// fundamental WinRT types.
+var goTypeSizes = map[string]int{
+	"bool": 1, "byte": 1, "int8": 1, "uint8": 1,
+	"int16": 2, "uint16": 2,
+	"int32": 4, "uint32": 4, "float32": 4,
+	"int64": 8, "uint64": 8, "float64": 8,
+}
+
+// structByValueType reports the unsigned integer type a struct should be loaded
+// through in order to be passed in a register, or "" if it must be passed by
+// reference.
+//
+// Both the x64 and the AArch64 calling conventions put an aggregate of eight
+// bytes or fewer in a single register, and pass anything larger than sixteen by
+// reference. Sizes in between differ between the two, so only the small case is
+// claimed here; everything else keeps its address taken.
+//
+// Only sizes of exactly 1, 2, 4 or 8 are accepted. Any other total means the
+// fields do not pack without padding, and the sum would not describe the real
+// layout.
+func (g *generator) structByValueType(typeDef *winmd.TypeDef) string {
+	fields, err := typeDef.ResolveFieldList(typeDef.Ctx())
+	if err != nil {
+		return ""
+	}
+
+	size := 0
+	for _, f := range fields {
+		fSig, err := f.Signature.Reader().Field(typeDef.Ctx())
+		if err != nil {
+			return ""
+		}
+		fieldType, err := g.elementType(typeDef.Ctx(), fSig.Field)
+		if err != nil {
+			return ""
+		}
+
+		name := fieldType.name
+		if fieldType.IsEnum {
+			name = fieldType.UnderlyingEnumType
+		}
+		fieldSize, ok := goTypeSizes[name]
+		if !ok {
+			return "" // nested struct, string or pointer: do not guess
+		}
+		size += fieldSize
+	}
+
+	switch size {
+	case 1:
+		return "uint8"
+	case 2:
+		return "uint16"
+	case 4:
+		return "uint32"
+	case 8:
+		return "uint64"
+	default:
+		return ""
+	}
+}
+
 func (g *generator) createGenStruct(typeDef *winmd.TypeDef) (*genStruct, error) {
 	// structs do not have methods, only fields
 	fields, err := typeDef.ResolveFieldList(typeDef.Ctx())
@@ -967,6 +1030,14 @@ func (g *generator) elementType(ctx *types.Context, e types.Element) (*genParamT
 			isEnum = true
 			enumType = enumData.Type
 		}
+		// A struct small enough to travel in a register must be passed by
+		// value; taking its address would hand the callee a pointer where it
+		// expects the value itself.
+		byValueType := ""
+		if !isEnum {
+			byValueType = g.structByValueType(elementTypeDef)
+		}
+
 		return &genParamType{
 			namespace:          namespace,
 			name:               name,
@@ -975,6 +1046,7 @@ func (g *generator) elementType(ctx *types.Context, e types.Element) (*genParamT
 			IsArray:            false,
 			IsEnum:             isEnum,
 			UnderlyingEnumType: enumType,
+			ByValueType:        byValueType,
 			defaultValue:       g.elementDefaultValue(ctx, e),
 		}, nil
 	case types.ELEMENT_TYPE_VAR:

--- a/internal/codegen/templates.go
+++ b/internal/codegen/templates.go
@@ -153,6 +153,11 @@ type genParamType struct {
 	IsEnum             bool
 	UnderlyingEnumType string
 
+	// ByValueType is the unsigned integer type a small struct is loaded
+	// through so it can be passed in a register. Empty when the struct is
+	// passed by reference instead.
+	ByValueType string
+
 	defaultValue genDefaultValue
 }
 

--- a/internal/codegen/templates/funcimpl.tmpl
+++ b/internal/codegen/templates/funcimpl.tmpl
@@ -61,6 +61,8 @@ hr, _, _ := syscall.SyscallN(
             {{end -}}
         {{else if .Type.IsGeneric -}}
             uintptr({{.GoVarName}}),   // in {{.GoTypeName}}
+        {{else if .Type.ByValueType -}}
+            uintptr(*(*{{.Type.ByValueType}})(unsafe.Pointer(&{{.GoVarName}}))),   // in {{.GoTypeName}}
         {{else -}}
             uintptr(unsafe.Pointer(&{{.GoVarName}})),   // in {{.GoTypeName}}
         {{end -}}

--- a/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
+++ b/windows/devices/bluetooth/advertisement/bluetoothleadvertisementwatcher.go
@@ -226,8 +226,8 @@ func (v *iBluetoothLEAdvertisementWatcher) AddReceived(handler *foundation.Typed
 func (v *iBluetoothLEAdvertisementWatcher) RemoveReceived(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveReceived,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -256,8 +256,8 @@ func (v *iBluetoothLEAdvertisementWatcher) AddStopped(handler *foundation.TypedE
 func (v *iBluetoothLEAdvertisementWatcher) RemoveStopped(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveStopped,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/bluetoothledevice.go
+++ b/windows/devices/bluetooth/bluetoothledevice.go
@@ -179,8 +179,8 @@ func (v *iBluetoothLEDevice) AddConnectionStatusChanged(handler *foundation.Type
 func (v *iBluetoothLEDevice) RemoveConnectionStatusChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveConnectionStatusChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -399,8 +399,8 @@ func (v *iBluetoothLEDevice6) AddConnectionParametersChanged(handler *foundation
 func (v *iBluetoothLEDevice6) RemoveConnectionParametersChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveConnectionParametersChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -429,8 +429,8 @@ func (v *iBluetoothLEDevice6) AddConnectionPhyChanged(handler *foundation.TypedE
 func (v *iBluetoothLEDevice6) RemoveConnectionPhyChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveConnectionPhyChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattcharacteristic.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattcharacteristic.go
@@ -245,8 +245,8 @@ func (v *iGattCharacteristic) AddValueChanged(valueChangedHandler *foundation.Ty
 func (v *iGattCharacteristic) RemoveValueChanged(valueChangedEventCookie foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveValueChanged,
-		uintptr(unsafe.Pointer(v)),                        // this
-		uintptr(unsafe.Pointer(&valueChangedEventCookie)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                                    // this
+		uintptr(*(*uint64)(unsafe.Pointer(&valueChangedEventCookie))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattlocalcharacteristic.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattlocalcharacteristic.go
@@ -354,8 +354,8 @@ func (v *iGattLocalCharacteristic) AddSubscribedClientsChanged(handler *foundati
 func (v *iGattLocalCharacteristic) RemoveSubscribedClientsChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveSubscribedClientsChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -384,8 +384,8 @@ func (v *iGattLocalCharacteristic) AddReadRequested(handler *foundation.TypedEve
 func (v *iGattLocalCharacteristic) RemoveReadRequested(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveReadRequested,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -414,8 +414,8 @@ func (v *iGattLocalCharacteristic) AddWriteRequested(handler *foundation.TypedEv
 func (v *iGattLocalCharacteristic) RemoveWriteRequested(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveWriteRequested,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattreadrequest.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattreadrequest.go
@@ -156,8 +156,8 @@ func (v *iGattReadRequest) AddStateChanged(handler *foundation.TypedEventHandler
 func (v *iGattReadRequest) RemoveStateChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveStateChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattserviceprovider.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattserviceprovider.go
@@ -140,8 +140,8 @@ func (v *iGattServiceProvider) AddAdvertisementStatusChanged(handler *foundation
 func (v *iGattServiceProvider) RemoveAdvertisementStatusChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveAdvertisementStatusChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattsession.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsession.go
@@ -209,8 +209,8 @@ func (v *iGattSession) AddMaxPduSizeChanged(handler *foundation.TypedEventHandle
 func (v *iGattSession) RemoveMaxPduSizeChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveMaxPduSizeChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -239,8 +239,8 @@ func (v *iGattSession) AddSessionStatusChanged(handler *foundation.TypedEventHan
 func (v *iGattSession) RemoveSessionStatusChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveSessionStatusChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattsubscribedclient.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattsubscribedclient.go
@@ -116,8 +116,8 @@ func (v *iGattSubscribedClient) AddMaxNotificationSizeChanged(handler *foundatio
 func (v *iGattSubscribedClient) RemoveMaxNotificationSizeChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveMaxNotificationSizeChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/devices/bluetooth/genericattributeprofile/gattwriterequest.go
+++ b/windows/devices/bluetooth/genericattributeprofile/gattwriterequest.go
@@ -179,8 +179,8 @@ func (v *iGattWriteRequest) AddStateChanged(handler *foundation.TypedEventHandle
 func (v *iGattWriteRequest) RemoveStateChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveStateChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/media/control/globalsystemmediatransportcontrolssession.go
+++ b/windows/media/control/globalsystemmediatransportcontrolssession.go
@@ -546,8 +546,8 @@ func (v *iGlobalSystemMediaTransportControlsSession) AddTimelinePropertiesChange
 func (v *iGlobalSystemMediaTransportControlsSession) RemoveTimelinePropertiesChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveTimelinePropertiesChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -576,8 +576,8 @@ func (v *iGlobalSystemMediaTransportControlsSession) AddPlaybackInfoChanged(hand
 func (v *iGlobalSystemMediaTransportControlsSession) RemovePlaybackInfoChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemovePlaybackInfoChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -606,8 +606,8 @@ func (v *iGlobalSystemMediaTransportControlsSession) AddMediaPropertiesChanged(h
 func (v *iGlobalSystemMediaTransportControlsSession) RemoveMediaPropertiesChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveMediaPropertiesChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {

--- a/windows/media/control/globalsystemmediatransportcontrolssessionmanager.go
+++ b/windows/media/control/globalsystemmediatransportcontrolssessionmanager.go
@@ -133,8 +133,8 @@ func (v *iGlobalSystemMediaTransportControlsSessionManager) AddCurrentSessionCha
 func (v *iGlobalSystemMediaTransportControlsSessionManager) RemoveCurrentSessionChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveCurrentSessionChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {
@@ -163,8 +163,8 @@ func (v *iGlobalSystemMediaTransportControlsSessionManager) AddSessionsChanged(h
 func (v *iGlobalSystemMediaTransportControlsSessionManager) RemoveSessionsChanged(token foundation.EventRegistrationToken) error {
 	hr, _, _ := syscall.SyscallN(
 		v.VTable().RemoveSessionsChanged,
-		uintptr(unsafe.Pointer(v)),      // this
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(unsafe.Pointer(v)),                  // this
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
 	)
 
 	if hr != 0 {


### PR DESCRIPTION
A struct small enough to travel in a register is passed in one by both the x64 and AArch64 calling conventions. The generated call takes its address instead, so the callee reads a pointer where it expects the value.

`Windows.UI.Color` shows it plainly — it's four bytes:

```go
func (v *iSolidColorBrush) SetColor(value ui.Color) error {
	hr, _, _ := syscall.SyscallN(
		v.VTable().SetColor,
		uintptr(unsafe.Pointer(v)),      // this
		uintptr(unsafe.Pointer(&value)), // in ui.Color   <-- address, not value
	)
```

`SolidColorBrush.Color` therefore receives the low half of a stack address as ARGB. In a XAML app that means every brush comes out a **different colour on each run**, which is how I found it.

## What this changes in this repo

`foundation.EventRegistrationToken` is the same shape at eight bytes, so **every `Remove*` method here passes a pointer where the token is expected** — `RemoveReceived`, `RemoveConnectionStatusChanged`, `RemoveValueChanged` and the rest. Unsubscribing has never delivered the right token.

That's the entire committed diff: 11 files, all `EventRegistrationToken`.

```diff
-		uintptr(unsafe.Pointer(&token)), // in foundation.EventRegistrationToken
+		uintptr(*(*uint64)(unsafe.Pointer(&token))), // in foundation.EventRegistrationToken
```

So unlike #121, #122 and #123, this one is **not** a byte-identical regeneration — it's a behavioural fix, and worth a careful look. If you'd rather land it separately from the others, it's independent of all three.

## Scope of the rule

Deliberately conservative:

| size | x64 | AArch64 | handled |
|---|---|---|---|
| 1, 2, 4, 8 | register | register | **yes, by value** |
| 9–16 | by reference | two registers | no — differs, left alone |
| > 16 | by reference | by reference | no — current behaviour already correct |

Only totals of exactly 1, 2, 4 or 8 are claimed. Any other sum means the fields don't pack without padding and the total wouldn't describe the real layout, so it keeps its address taken. Nested structs, strings and pointers bail out rather than guess.

`Thickness` and `CornerRadius` (32 bytes) verifiably keep `uintptr(unsafe.Pointer(&value))`; `float64` and other primitives are untouched.

## Verification

- `GOOS=windows go build ./...` clean on both `arm64` and `amd64`; `go test ./...` passes.
- Generated `SolidColorBrush.Color` becomes `uintptr(*(*uint32)(unsafe.Pointer(&value)))`, and colours render correctly in a XAML islands app instead of varying per launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
