### PR TITLE
Answer IAgileObject from delegates

### DIFF
--- a/internal/delegate/delegate.go
+++ b/internal/delegate/delegate.go
@@ -20,6 +20,13 @@ var (
 	invokeCallback         = syscall.NewCallback(invoke)
 )
 
+// iidIAgileObject is IID_IAgileObject.
+//
+// It is a marker interface with no methods of its own: an object claims it to
+// say it has no apartment affinity and may be called from any of them without
+// marshalling.
+var iidIAgileObject = ole.NewGUID("{94ea2b94-e9cc-49e0-c0ff-ee64ca8f5b90}")
+
 // Delegate represents a WinRT delegate class.
 type Delegate interface {
 	GetIID() *ole.GUID
@@ -87,7 +94,13 @@ func queryInterface(instancePtr unsafe.Pointer, iidPtr unsafe.Pointer, ppvObject
 
 	// This function must adhere to the QueryInterface defined here:
 	// https://docs.microsoft.com/en-us/windows/win32/api/unknwn/nn-unknwn-iunknown
-	if iid := (*ole.GUID)(iidPtr); ole.IsEqualGUID(iid, instance.GetIID()) || ole.IsEqualGUID(iid, ole.IID_IUnknown) || ole.IsEqualGUID(iid, ole.IID_IInspectable) {
+	// IAgileObject is answered because these delegates really are agile: the
+	// vtable is a fixed set of Go callbacks with no apartment affinity, so
+	// holding one from another apartment needs no marshalling. Without it, any
+	// API that requires an agile callback rejects the delegate with
+	// E_NOTAGILE (0x8000001C) - DispatcherQueue.TryEnqueue, for one, which is
+	// how work gets back onto a UI thread.
+	if iid := (*ole.GUID)(iidPtr); ole.IsEqualGUID(iid, instance.GetIID()) || ole.IsEqualGUID(iid, ole.IID_IUnknown) || ole.IsEqualGUID(iid, ole.IID_IInspectable) || ole.IsEqualGUID(iid, iidIAgileObject) {
 		*ppvObject = instancePtr
 	} else {
 		*ppvObject = nil


### PR DESCRIPTION
Passing a generated delegate to an API that requires an agile callback fails:

```
DispatcherQueue.TryEnqueue: 0x8000001C: The object must support the IAgileObject interface
```

`0x8000001C` is `E_NOTAGILE`. `queryInterface` in `internal/delegate` answers for the delegate's own IID, `IUnknown` and `IInspectable`, so any caller that asks for `IAgileObject` gets `E_NOINTERFACE` and refuses the callback.

## Why it matters

`DispatcherQueue.TryEnqueue` is the supported way to get back onto a UI thread from another thread — which, in Go, means from any goroutine that did some work. Because the handler has to be created by the goroutine doing the enqueuing, it is never agile, so the whole pattern is unavailable. In a XAML app that rules out updating the UI after an HTTP request, a file read, or anything else that shouldn't block the message loop.

The same applies to any WinRT API documented as requiring an agile completion handler.

## Why answering it is correct

These delegates genuinely have no apartment affinity. The vtable is a fixed set of Go callbacks (`internal/delegate` registers exactly four, shared by every instance), and nothing in the COM plumbing is bound to a thread. An apartment holding one can call it directly with no marshalling, which is the definition of agile — and is why C++/WinRT marks its own delegate implementations agile by default.

`IAgileObject` is a marker interface with no methods beyond `IUnknown`, so implementing it is returning the same pointer, exactly as the existing cases do.

Whether the *callback body* is thread-safe is a separate question and remains the caller's, unchanged by this: `TryEnqueue` still guarantees the callback runs on the queue's thread.

## Verification

- `go build ./...` and `GOOS=windows go build ./...` clean; `go test ./...` passes.
- **`go generate ./...` produces no change under `windows/`** — `internal/delegate` is hand-written, so nothing generated is affected.
- With the fix, `DispatcherQueue.TryEnqueue` accepts a `DispatcherQueueHandler` created on a goroutine and invokes it on the UI thread. Verified in a XAML islands app: before, every enqueue returned `E_NOTAGILE`; after, the callbacks arrive and can touch the visual tree.

Independent of #121, #122, #123 and #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
